### PR TITLE
Add embedding cache for faster memory search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Assistente de desenvolvimento baseado em IA com suporte a contextos de até **16
 ## Principais recursos
 
 - **Memória persistente** com busca vetorial (FAISS)
+- **Cache de embeddings** para acelerar consultas repetidas
 - **Limpeza automática de memórias** e feedback de uso
 - **Análise de código** com construção de grafo de dependências
 - **Monitoramento de logs** detectando padrões de erro

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,4 +10,5 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - **Exemplos de configuração**: disponibilizar modelos de `config.yaml` e `tasks.yaml` para facilitar o uso.
 - (adicione novos itens aqui)
 - **Automação incremental**: permitir que o projeto evolua com novas funções de forma contínua.
+- **Cache de memória**: reutilizar embeddings e consultas frequentes para acelerar o aprendizado.
 


### PR DESCRIPTION
## Summary
- cache embeddings in `MemoryManager` to avoid repeated model calls
- document embedding cache feature in README
- add roadmap note about memory caching
- test embedding caching behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429f4508588320bf076c247de34951