### PR TITLE
Add call tracking to analyzer

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,26 @@
+import ast
+from devai.analyzer import CodeAnalyzer
+
+class DummyMemory:
+    def __init__(self):
+        self.saved = []
+    def save(self, entry, update_feedback=False):
+        self.saved.append(entry)
+    conn = type('conn', (), {'cursor': lambda self: type('cur', (), {'execute': lambda self, *a, **k: None, 'fetchall': lambda self: []})()})()
+    def add_semantic_relation(self, *a, **k):
+        pass
+
+
+def test_get_function_calls():
+    code = """
+def bar():
+    pass
+
+def foo():
+    bar()
+"""
+    tree = ast.parse(code)
+    node = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "foo"][0]
+    analyzer = CodeAnalyzer(".", DummyMemory())
+    calls = analyzer._get_function_calls(node)
+    assert {"function": "bar", "line": 6} in calls


### PR DESCRIPTION
## Summary
- track function call locations while parsing code
- store call relations in the dependency graph
- expose helper `_get_function_calls`
- record call edges when building semantic relations
- test new call extraction logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a3731d6083208fd5b10fb2c3e0a1