### PR TITLE
Implement safe update mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ O código foi dividido em módulos dentro do pacote `devai/`, facilitando a incl
 - `core.py` – orquestração principal
 - `cli.py` – interface de linha de comando
 - `lint.py` – checagem simples de TODOs
+- `update_manager.py` – aplica mudancas com rollback caso os testes falhem
 
 Sinta‑se livre para expandir cada módulo conforme necessário.
 ## Roadmap

--- a/devai/update_manager.py
+++ b/devai/update_manager.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable, Iterable, List
+
+from .config import logger
+
+
+class UpdateManager:
+    """Safely apply changes to a file and verify using tests."""
+
+    def __init__(self, tests_cmd: Iterable[str] | None = None) -> None:
+        self.tests_cmd: List[str] = list(tests_cmd or ["pytest", "-q"])
+
+    def _backup(self, path: Path) -> Path:
+        backup = path.with_suffix(path.suffix + ".bak")
+        shutil.copy2(path, backup)
+        logger.info("Backup criado", file=str(path), backup=str(backup))
+        return backup
+
+    def _restore(self, backup: Path, original: Path) -> None:
+        shutil.move(str(backup), str(original))
+        logger.warning(
+            "Arquivo restaurado devido a falha nos testes", file=str(original)
+        )
+
+    def run_tests(self) -> bool:
+        logger.info("Executando testes para validacao")
+        proc = subprocess.run(
+            self.tests_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        logger.info("Testes finalizados", returncode=proc.returncode)
+        return proc.returncode == 0
+
+    def safe_apply(
+        self, file_path: str | Path, apply_func: Callable[[Path], None], max_attempts: int = 1
+    ) -> bool:
+        """Apply modifications with automatic rollback if tests fail."""
+        path = Path(file_path)
+        attempt = 0
+        while attempt < max_attempts:
+            attempt += 1
+            backup = self._backup(path)
+            try:
+                apply_func(path)
+                if self.run_tests():
+                    backup.unlink(missing_ok=True)
+                    logger.info(
+                        "Atualizacao aplicada com sucesso", file=str(path)
+                    )
+                    return True
+                self._restore(backup, path)
+            except Exception as e:  # pragma: no cover - unexpected errors
+                logger.error("Erro na atualizacao", file=str(path), error=str(e))
+                self._restore(backup, path)
+                raise
+        logger.error(
+            "Falha em validar atualizacao apos tentativas", file=str(path)
+        )
+        return False

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -1,0 +1,24 @@
+from devai.update_manager import UpdateManager
+
+
+def test_safe_apply_success(tmp_path, monkeypatch):
+    file = tmp_path / "f.txt"
+    file.write_text("old")
+    mgr = UpdateManager()
+    monkeypatch.setattr(mgr, "run_tests", lambda: True)
+    result = mgr.safe_apply(file, lambda p: p.write_text("new"))
+    assert result
+    assert file.read_text() == "new"
+    assert not file.with_suffix(".txt.bak").exists()
+
+
+def test_safe_apply_failure(tmp_path, monkeypatch):
+    file = tmp_path / "f.txt"
+    file.write_text("old")
+    mgr = UpdateManager()
+    monkeypatch.setattr(mgr, "run_tests", lambda: False)
+    result = mgr.safe_apply(file, lambda p: p.write_text("new"))
+    assert not result
+    assert file.read_text() == "old"
+    # o backup eh movido de volta ao restaurar
+    assert not file.with_suffix(".txt.bak").exists()


### PR DESCRIPTION
## Summary
- add `UpdateManager` helper to safely modify files and rollback on failing tests
- document the new module in the README
- cover the new functionality with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843178673308320b69362f294a455be