### PR TITLE
Improve CLI with file management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ python -m devai --cli
 
 Os comandos disponíveis na CLI são listados ao iniciar o programa, como `/memoria`, `/tarefa` e `/grafo`.
 
+### Gerenciamento de arquivos
+
+Além das tarefas padrão, a CLI permite explorar e modificar o diretório definido em `CODE_ROOT` (por padrão `./app`):
+
+- `/ls [caminho]` lista arquivos e subpastas.
+- `/abrir <arquivo> [ini] [fim]` exibe linhas específicas de um arquivo.
+- `/editar <arquivo> <linha> <novo>` altera uma linha individual.
+
 ## Testes
 
 Instale as dependências de desenvolvimento e execute:

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -16,6 +16,9 @@ async def cli_main():
     print("/analisar <função> - Analisa impacto de mudanças")
     print("/verificar - Verifica conformidade com especificação")
     print("/grafo - Mostra grafo de dependências")
+    print("/ls [caminho] - Lista arquivos e pastas")
+    print("/abrir <arquivo> [ini] [fim] - Mostra linhas do arquivo")
+    print("/editar <arquivo> <linha> <novo> - Edita linha do arquivo")
     print("/sair - Encerra")
     while True:
         try:
@@ -59,6 +62,27 @@ async def cli_main():
                 print("\nConexões:")
                 for link in graph["links"]:
                     print(f"{link['source']} -> {link['target']}")
+            elif user_input.startswith("/ls"):
+                path = user_input[len("/ls"):].strip()
+                items = await ai.analyzer.list_dir(path)
+                for item in items:
+                    print(item)
+            elif user_input.startswith("/abrir "):
+                parts = user_input[len("/abrir "):].split()
+                file = parts[0]
+                start = int(parts[1]) if len(parts) > 1 else 1
+                end = int(parts[2]) if len(parts) > 2 else start
+                lines = await ai.analyzer.read_lines(file, start, end)
+                for i, line in enumerate(lines, start=start):
+                    print(f"{i}: {line}")
+            elif user_input.startswith("/editar "):
+                parts = user_input[len("/editar "):].split(maxsplit=2)
+                if len(parts) < 3:
+                    print("Uso: /editar <arquivo> <linha> <novo>")
+                else:
+                    file, line_no, new_line = parts[0], int(parts[1]), parts[2]
+                    ok = await ai.analyzer.edit_line(file, line_no, new_line)
+                    print("✅ Linha atualizada" if ok else "Falha ao editar")
             else:
                 response = await ai.generate_response(user_input)
                 print("\nResposta:")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,3 +25,4 @@ def test_cli_exit(monkeypatch, capsys):
     asyncio.run(run())
     out = capsys.readouterr().out
     assert "Comandos disponíveis" in out
+    assert "/ls" in out


### PR DESCRIPTION
## Summary
- support listing directories, reading and editing file lines in `CodeAnalyzer`
- expose `/ls`, `/abrir` and `/editar` commands in CLI
- document new CLI commands in README
- add tests for new analyzer utilities and CLI output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684312fd2ee88320803aef3b5f4c026d