### PR TITLE
Add simple web interface and file API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Assistente de desenvolvimento baseado em IA com suporte a contextos de até **16
 - **Monitoramento de logs** detectando padrões de erro
 - **Execução de testes automatizados e análise estática**
 - **API FastAPI** e **interface de linha de comando**
+- **Interface web opcional** em `/static/index.html` para conversar com a IA e explorar arquivos
 - Métricas expostas em `/metrics`
 
 ## Configuração
@@ -31,6 +32,8 @@ API_PORT: 8000
 ```bash
 python -m devai --api
 ```
+
+Com o servidor ativo, acesse `http://localhost:8000/static/index.html` para utilizar a interface web.
 
 - **Interface de linha de comando**:
 

--- a/devai/core.py
+++ b/devai/core.py
@@ -83,6 +83,21 @@ class CodeMemoryAI:
             await self.analyzer.deep_scan_app()
             return {"status": "rescanned"}
 
+        @self.app.get("/files")
+        async def list_files(path: str = ""):
+            """Expose CODE_ROOT contents through the API."""
+            return await self.analyzer.list_dir(path)
+
+        @self.app.get("/file")
+        async def get_file(file: str, start: int = 1, end: Optional[int] = None):
+            lines = await self.analyzer.read_lines(file, start, end)
+            return {"file": file, "lines": lines}
+
+        @self.app.post("/file/edit")
+        async def edit_file(file: str, line: int, content: str):
+            ok = await self.analyzer.edit_line(file, line, content)
+            return {"status": "ok" if ok else "error"}
+
         os.makedirs("static", exist_ok=True)
         self.app.mount("/static", StaticFiles(directory="static"), name="static")
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+<meta charset="UTF-8">
+<title>DevAI Interface</title>
+<style>
+  body { margin: 0; font-family: Arial, sans-serif; display: flex; height: 100vh; }
+  #sidebar { width: 250px; background: #f5f5f5; overflow-y: auto; border-right: 1px solid #ccc; padding: 10px; }
+  #chat { flex: 1; display: flex; flex-direction: column; }
+  #messages { flex: 1; padding: 10px; overflow-y: auto; white-space: pre-wrap; }
+  #input { display: flex; padding: 10px; border-top: 1px solid #ccc; }
+  #input textarea { flex: 1; }
+</style>
+</head>
+<body>
+<div id="sidebar">
+  <h3>Arquivos</h3>
+  <ul id="fileList"></ul>
+</div>
+<div id="chat">
+  <div id="messages"></div>
+  <div id="input">
+    <textarea id="query" rows="3"></textarea>
+    <button id="send">Enviar</button>
+  </div>
+</div>
+<script>
+async function refreshFiles(path="") {
+  const res = await fetch('/files?path=' + encodeURIComponent(path));
+  const files = await res.json();
+  const list = document.getElementById('fileList');
+  list.innerHTML = '';
+  files.forEach(f => {
+    const li = document.createElement('li');
+    li.textContent = f;
+    li.style.cursor = 'pointer';
+    li.onclick = () => openFile(f);
+    list.appendChild(li);
+  });
+}
+async function openFile(file) {
+  const res = await fetch('/file?file=' + encodeURIComponent(file));
+  const data = await res.json();
+  alert(data.lines.join('\n'));
+}
+async function send() {
+  const q = document.getElementById('query').value.trim();
+  if (!q) return;
+  const res = await fetch('/analyze?query=' + encodeURIComponent(q), {method: 'POST'});
+  const text = await res.text();
+  const div = document.createElement('div');
+  div.textContent = '> ' + q + '\n' + text;
+  document.getElementById('messages').appendChild(div);
+  document.getElementById('query').value = '';
+  document.getElementById('messages').scrollTop = document.getElementById('messages').scrollHeight;
+}
+document.getElementById('send').onclick = send;
+refreshFiles();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create basic chat-style HTML interface under `static/`
- expose file browsing and editing via new FastAPI endpoints
- document new interface in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431a3eb48083209428cf938cc04e8d