### PR TITLE
Add file history and management features

### DIFF
--- a/devai/cli.py
+++ b/devai/cli.py
@@ -19,6 +19,10 @@ async def cli_main():
     print("/ls [caminho] - Lista arquivos e pastas")
     print("/abrir <arquivo> [ini] [fim] - Mostra linhas do arquivo")
     print("/editar <arquivo> <linha> <novo> - Edita linha do arquivo")
+    print("/novoarq <arquivo> [conteudo] - Cria novo arquivo")
+    print("/novapasta <caminho> - Cria nova pasta")
+    print("/deletar <caminho> - Remove arquivo ou pasta")
+    print("/historico <arquivo> - Mostra histórico de mudanças")
     print("/sair - Encerra")
     while True:
         try:
@@ -83,6 +87,27 @@ async def cli_main():
                     file, line_no, new_line = parts[0], int(parts[1]), parts[2]
                     ok = await ai.analyzer.edit_line(file, line_no, new_line)
                     print("✅ Linha atualizada" if ok else "Falha ao editar")
+            elif user_input.startswith("/novoarq "):
+                parts = user_input[len("/novoarq "):].split(maxsplit=1)
+                file = parts[0]
+                content = parts[1] if len(parts) > 1 else ""
+                ok = await ai.analyzer.create_file(file, content)
+                print("✅ Arquivo criado" if ok else "Falha ao criar")
+            elif user_input.startswith("/novapasta "):
+                path = user_input[len("/novapasta "):].strip()
+                ok = await ai.analyzer.create_directory(path)
+                print("✅ Pasta criada" if ok else "Falha ao criar pasta")
+            elif user_input.startswith("/deletar "):
+                path = user_input[len("/deletar "):].strip()
+                ok = await ai.analyzer.delete_file(path)
+                if not ok:
+                    ok = await ai.analyzer.delete_directory(path)
+                print("✅ Removido" if ok else "Falha ao remover")
+            elif user_input.startswith("/historico "):
+                file = user_input[len("/historico "):].strip()
+                hist = await ai.analyzer.get_history(file)
+                for h in hist:
+                    print(json.dumps(h, indent=2))
             else:
                 response = await ai.generate_response(user_input)
                 print("\nResposta:")

--- a/devai/config.py
+++ b/devai/config.py
@@ -19,6 +19,8 @@ class Config:
             "EMBEDDING_MODEL": "all-MiniLM-L6-v2",
             "TASK_DEFINITIONS": "tasks.yaml",
             "LOG_DIR": "./logs",
+            "FILE_HISTORY": "file_history.json",
+            "API_TOKEN": os.getenv("API_TOKEN", ""),
             "API_PORT": 8000,
             "LEARNING_LOOP_INTERVAL": 300,
             "MAX_CONTEXT_LENGTH": 160000,

--- a/devai/file_history.py
+++ b/devai/file_history.py
@@ -1,0 +1,43 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional
+
+
+class FileHistory:
+    """Simple file change logger."""
+
+    def __init__(self, history_file: str):
+        self.path = Path(history_file)
+        if self.path.exists():
+            try:
+                self.entries = json.loads(self.path.read_text())
+            except Exception:
+                self.entries = []
+        else:
+            self.entries = []
+
+    def _save(self) -> None:
+        self.path.write_text(json.dumps(self.entries, indent=2))
+
+    def record(
+        self,
+        file_path: str,
+        change_type: str,
+        old: Optional[List[str]] = None,
+        new: Optional[List[str]] = None,
+    ) -> None:
+        entry: Dict[str, object] = {
+            "path": file_path,
+            "type": change_type,
+            "timestamp": datetime.now().isoformat(),
+        }
+        if old is not None:
+            entry["old"] = old
+        if new is not None:
+            entry["new"] = new
+        self.entries.append(entry)
+        self._save()
+
+    def history(self, file_path: str) -> List[Dict]:
+        return [e for e in self.entries if e.get("path") == file_path]

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,12 @@
+from devai.file_history import FileHistory
+
+
+def test_history_record(tmp_path):
+    log = tmp_path / "hist.json"
+    hist = FileHistory(str(log))
+    hist.record("a.txt", "create", new=["x"])
+    hist.record("a.txt", "edit", old=["x"], new=["y"])
+    items = hist.history("a.txt")
+    assert len(items) == 2
+    assert items[0]["type"] == "create"
+    assert items[1]["old"] == ["x"]


### PR DESCRIPTION
## Summary
- introduce `FileHistory` module for simple versioning
- allow `CodeAnalyzer` to create/delete files and directories and record history
- extend CLI with commands to create/remove files and folders and view history
- add API endpoints for file/directory management with token auth
- store API token and history path in config
- cover new features with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431da880808320a27a5d2d808f7dba