### PR TITLE
Add dependency check warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ API_SECRET: "sua-chave"
 
 2. Defina a variável de ambiente `OPENROUTER_API_KEY` com sua chave de acesso.
 
+3. Instale as dependências do projeto para habilitar a comunicação real com o OpenRouter:
+
+```bash
+pip install -r requirements.txt
+```
+
+O DevAI traz versões simplificadas de algumas bibliotecas (como `aiohttp` e `fastapi`) usadas apenas em testes offline. O módulo `dependency_check` avisará caso essas versões estejam ativas, recomendando a instalação dos pacotes reais.
+
 ## Executando
 
 - **Servidor API**:

--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -4,6 +4,7 @@ import argparse
 from .config import config
 from .core import CodeMemoryAI
 from .cli import cli_main
+from .dependency_check import check_dependencies
 
 
 def main():
@@ -11,6 +12,7 @@ def main():
     parser.add_argument("--api", action="store_true", help="Inicia o servidor API")
     parser.add_argument("--cli", action="store_true", help="Inicia a interface de linha de comando")
     args = parser.parse_args()
+    check_dependencies()
     if not config.OPENROUTER_API_KEY:
         print("Erro: A variável de ambiente OPENROUTER_API_KEY não está definida")
         return

--- a/devai/dependency_check.py
+++ b/devai/dependency_check.py
@@ -1,0 +1,20 @@
+import importlib
+import os
+from .config import logger
+
+
+def check_dependencies() -> None:
+    """Warn if simplified stubs are being used instead of real libraries."""
+    project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    libs = ["aiohttp", "fastapi", "uvicorn", "networkx"]
+    for lib in libs:
+        try:
+            mod = importlib.import_module(lib)
+            path = getattr(mod, "__file__", "")
+            if path and os.path.abspath(path).startswith(os.path.join(project_dir, lib)):
+                logger.warning(
+                    "Dependência %s está usando versão simplificada; instale as bibliotecas reais para integração completa",
+                    lib,
+                )
+        except Exception as e:  # pragma: no cover - optional dependency
+            logger.error("Falha ao importar %s", lib, error=str(e))


### PR DESCRIPTION
## Summary
- detect stub versions of aiohttp and others
- warn users when simplified libraries are active
- document installing requirements.txt to enable real API usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436c913c508320891d238a949ecba0