### PR TITLE
Add RLHF placeholders and chain-of-thought support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Assistente de desenvolvimento baseado em IA com suporte a contextos de até **16
 - **Notificações por e-mail** opcionais
 - **Integração contínua via GitHub Actions**
 - **Refatoração automática validada por testes**
+- **Prompts Chain-of-Thought** para melhor raciocínio
+- **Estrutura inicial para fine-tuning via RLHF e sandbox de execução**
 
 ## Configuração
 
@@ -137,6 +139,9 @@ Melhorias em andamento:
 - Automação incremental do projeto
 - Cache de memória para acelerar consultas
 - Sistema de plugins para novas tarefas *(implementado)*
+- Prompts com raciocínio em etapas *(Chain-of-Thought)*
+- Estrutura para treinamento via RLHF
+- Sandbox de execução para testes isolados *(planejado)*
 - Relatórios de cobertura integrados
 - Monitoramento de complexidade ao longo do tempo
   (histórico salvo em `complexity_history.json`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,4 +22,7 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - **Monitoramento de complexidade do código ao longo do tempo** *(implementado)*
 - **Integração com IDEs (VSCode, etc.)** *(futuro)*
 - **Treinamento incremental com dados do histórico** *(futuro)*
+- **Fine-tuning com RLHF** *(planejado)*
+- **Sandbox de execução com containers** *(planejado)*
+- **Prompts com Chain-of-Thought** *(parcialmente implementado)*
 

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -99,6 +99,10 @@ async def cli_main():
                 print("✅ Pasta criada" if ok else "Falha ao criar pasta")
             elif user_input.startswith("/deletar "):
                 path = user_input[len("/deletar "):].strip()
+                confirm = input("Tem certeza que deseja remover? [s/N] ").lower()
+                if confirm != "s":
+                    print("Operação cancelada")
+                    continue
                 ok = await ai.analyzer.delete_file(path)
                 if not ok:
                     ok = await ai.analyzer.delete_directory(path)

--- a/devai/core.py
+++ b/devai/core.py
@@ -215,10 +215,13 @@ class CodeMemoryAI:
 
     async def generate_response(self, query: str) -> str:
         try:
+            if len(query.split()) < 3:
+                return "Por favor, forneça mais detalhes sobre sua solicitação."
+
             contextual_memories = self.memory.search(query, level="short")
             relevant_chunks = self._find_relevant_code(query)
-            from .prompt_utils import build_user_query_prompt
-            prompt = build_user_query_prompt(query, contextual_memories, relevant_chunks)
+            from .prompt_utils import build_cot_prompt
+            prompt = build_cot_prompt(query, contextual_memories, relevant_chunks)
             return await self.ai_model.generate(prompt)
         except Exception as e:
             logger.error("Erro ao gerar resposta", error=str(e))

--- a/devai/prompt_utils.py
+++ b/devai/prompt_utils.py
@@ -16,6 +16,12 @@ def build_user_query_prompt(query: str, memories: Sequence[Dict], chunks: Sequen
     return f"{memory_context}\n{code_context}\nUsuário: {query}\nIA:".strip()
 
 
+def build_cot_prompt(query: str, memories: Sequence[Dict], chunks: Sequence[Dict]) -> str:
+    """Compose a prompt encouraging step-by-step reasoning."""
+    base = build_user_query_prompt(query, memories, chunks)
+    return base + "\nVamos pensar passo a passo antes de responder."
+
+
 def build_analysis_prompt(code: str, issues: Sequence[str]) -> str:
     """Prompt asking the model to review a code snippet."""
     return (

--- a/devai/rlhf.py
+++ b/devai/rlhf.py
@@ -1,0 +1,18 @@
+class RLFineTuner:
+    """Placeholder for reinforcement learning fine-tuning."""
+
+    def __init__(self, memory_manager):
+        self.memory = memory_manager
+
+    def collect_examples(self):
+        """Gather examples from memory for future RLHF datasets."""
+        # TODO: Implement extraction of high quality interactions
+        return []
+
+    async def fine_tune(self, base_model: str, output_dir: str) -> None:
+        """Fine tune the language model with RLHF.
+
+        This method should integrate libraries such as `trl` or
+        `accelerate` in the future.
+        """
+        raise NotImplementedError("RLHF pipeline not implemented yet")

--- a/devai/sandbox.py
+++ b/devai/sandbox.py
@@ -1,0 +1,16 @@
+import subprocess
+from typing import List
+
+
+class Sandbox:
+    """Isolated execution environment using containers."""
+
+    def __init__(self, image: str = "python:3.10-slim"):
+        self.image = image
+
+    def run(self, command: List[str], timeout: int = 30) -> str:
+        """Run a command inside a container.
+
+        TODO: integrate with Docker/Podman for real isolation.
+        """
+        raise NotImplementedError("Sandbox execution not implemented yet")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,4 @@
+import asyncio
 from devai.core import CodeMemoryAI
 
 ai = object.__new__(CodeMemoryAI)
@@ -14,3 +15,20 @@ def test_extract_inputs():
 def test_infer_return_type():
     code = "def f():\n    return 1"
     assert CodeMemoryAI._infer_return_type(ai, code) == "number"
+
+
+def test_generate_response_short_query(monkeypatch):
+    ai.memory = type("M", (), {"search": lambda self, q, level=None, top_k=5: []})()
+    ai._find_relevant_code = lambda q: []
+
+    class DummyModel:
+        async def generate(self, prompt, max_length=0):
+            return "ok"
+
+    ai.ai_model = DummyModel()
+
+    async def run():
+        return await CodeMemoryAI.generate_response(ai, "oi")
+
+    result = asyncio.run(run())
+    assert "forneça mais detalhes" in result

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,0 +1,10 @@
+from devai.prompt_utils import build_cot_prompt
+
+
+def test_build_cot_prompt():
+    prompt = build_cot_prompt(
+        "teste",
+        memories=[{"similarity_score": 1.0, "content": "m", "tags": []}],
+        chunks=[{"file": "f.py", "type": "func", "name": "f", "dependencies": [], "code": "def f(): pass"}],
+    )
+    assert "passo a passo" in prompt


### PR DESCRIPTION
## Summary
- add RLFineTuner skeleton and sandbox placeholder modules
- implement Chain-of-Thought prompting and integrate in response generation
- request confirmation before destructive CLI actions
- reply with clarification request on short queries
- document new planned features
- test new prompt and core behaviour

## Testing
- `flake8 devai tests` *(fails: command not found)*
- `pylint -E devai` *(fails: command not found)*
- `bandit -r devai` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437f45af388320ba4ce8f2e8264ed3