### PR TITLE
Improve DevAI language and tasks

### DIFF
--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -1,0 +1,11 @@
+# Guia do Projeto DevAI
+
+Este arquivo permite descrever comandos e convenções específicas do projeto. O agente utiliza estas informações para compilar e testar corretamente.
+
+## Comandos principais
+
+- **Instalar dependências:** `pip install -r requirements.txt`
+- **Executar testes:** `pytest`
+- **Rodar linter:** `flake8 devai`
+
+Adicione aqui quaisquer passos extras para build ou uso de frameworks (por exemplo, `npm install`, `mvn test`).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Assistente de desenvolvimento baseado em IA com suporte a contextos de até **16
 - **Limpeza automática de memórias** e feedback de uso
 - **Análise de código** com construção de grafo de dependências
 - **Parser multilíngue** (Python, JS, C++, HTML)
+- **Suporte expandido a linguagens** (Java, C#, Ruby, PHP)
 - **Métricas de complexidade** das funções analisadas
 - **Acompanhamento da complexidade média do projeto**
 - **Monitoramento de logs** detectando padrões de erro
@@ -17,6 +18,7 @@ Assistente de desenvolvimento baseado em IA com suporte a contextos de até **16
 - **Relatórios de cobertura de testes**
 - **Tarefas extras** com pylint e mypy
 - **Análise de segurança com Bandit**
+- **Tarefa "Quality Suite" paralela para lint e testes**
 - **Monitoramento de complexidade ao longo do tempo**
 - **Cache inteligente de prompts** reaproveitando respostas similares
 - **Integração opcional com modelo local** para geração offline
@@ -25,6 +27,7 @@ Assistente de desenvolvimento baseado em IA com suporte a contextos de até **16
 - Métricas expostas em `/metrics` (CPU e memória)
 - **Histórico de uso de CPU/memória**
 - **Histórico de tarefas** e sistema de plugins
+- **Plugin de contexto de frameworks** lendo `package.json`, `requirements.txt` ou `pom.xml`
 - **Suporte a múltiplos modelos** configuráveis
 - **Notificações por e-mail** opcionais
 - **Integração contínua via GitHub Actions**
@@ -49,6 +52,8 @@ API_SECRET: "sua-chave"
 ```bash
 pip install -r requirements.txt
 ```
+
+4. (Opcional) Descreva comandos de build e testes adicionais em `PROJECT_GUIDE.md`.
 
 O DevAI traz versões simplificadas de algumas bibliotecas (como `aiohttp` e `fastapi`) usadas apenas em testes offline. O módulo `dependency_check` avisará caso essas versões estejam ativas, recomendando a instalação dos pacotes reais.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,4 +37,8 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - **Prompts com Chain-of-Thought** *(parcialmente implementado)*
 - **Planejamento multi-turn interativo** *(futuro)*
 - **Confirmação antes de ações críticas** *(futuro)*
+- **Painel web estilo IDE** com diffs e chat integrado *(futuro)*
+- **Componente de metacognição** para aprendizado contínuo *(futuro)*
+- **Paralelismo de tarefas** acelerando lint e testes *(implementado em parte)*
+- **Uso de modelos menores** para otimizar embeddings *(futuro)*
 

--- a/devai/analyzer.py
+++ b/devai/analyzer.py
@@ -46,7 +46,18 @@ class CodeAnalyzer:
 
     async def scan_app(self):
         tasks = []
-        patterns = ["*.py", "*.js", "*.ts", "*.cpp", "*.hpp", "*.html"]
+        patterns = [
+            "*.py",
+            "*.js",
+            "*.ts",
+            "*.cpp",
+            "*.hpp",
+            "*.html",
+            "*.java",
+            "*.cs",
+            "*.rb",
+            "*.php",
+        ]
         for pat in patterns:
             for file_path in self.code_root.rglob(pat):
                 if file_path.is_file():
@@ -133,6 +144,20 @@ class CodeAnalyzer:
             pattern = re.compile(r"function\s+(\w+)\s*\(")
         elif ftype in {"cpp", "hpp"}:
             pattern = re.compile(r"[\w:]+\s+(\w+)\s*\([^)]*\)\s*{", re.MULTILINE)
+        elif ftype == "java":
+            pattern = re.compile(
+                r"(?:public|protected|private|static|final|\s)+\s+[\w<>,\[\]]+\s+(\w+)\s*\(",
+                re.MULTILINE,
+            )
+        elif ftype == "cs":
+            pattern = re.compile(
+                r"(?:public|protected|private|internal|static|virtual|override|async|\s)+\s+[\w<>,\[\]]+\s+(\w+)\s*\(",
+                re.MULTILINE,
+            )
+        elif ftype == "rb":
+            pattern = re.compile(r"def\s+(\w+)")
+        elif ftype == "php":
+            pattern = re.compile(r"function\s+(\w+)\s*\(")
         if pattern:
             for m in pattern.finditer(content):
                 name = m.group(1)

--- a/plugins/framework_context.py
+++ b/plugins/framework_context.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import json
+import xml.etree.ElementTree as ET
+from typing import List, Dict
+
+
+def register(task_manager):
+    async def _perform_framework_context_task(self, task, *args):
+        root = Path(self.code_analyzer.code_root).parent
+        entries: List[Dict[str, List[str]]] = []
+        files = [root / "package.json", root / "requirements.txt", root / "pom.xml"]
+        for f in files:
+            if not f.exists():
+                continue
+            try:
+                if f.name == "package.json":
+                    data = json.loads(f.read_text())
+                    deps = list(data.get("dependencies", {}).keys())
+                elif f.suffix == ".xml":
+                    tree = ET.parse(f)
+                    deps = [d.text for d in tree.findall(".//dependency/artifactId")]
+                else:
+                    deps = [line.strip().split("==")[0] for line in f.read_text().splitlines() if line.strip() and not line.startswith("#")]
+                entries.append({f.name: deps})
+                self.memory.save(
+                    {
+                        "type": "framework_info",
+                        "content": f"Dependências em {f.name}",
+                        "metadata": {"file": f.name, "deps": deps},
+                        "tags": ["framework", "dependency"],
+                    }
+                )
+            except Exception:
+                continue
+        return entries or ["Nenhuma configuração detectada"]
+
+    task_manager.tasks["framework_context"] = {
+        "name": "Extrair Contexto de Frameworks",
+        "type": "framework_context",
+        "description": "Lê arquivos de config de frameworks para a memória",
+    }
+    setattr(task_manager, "_perform_framework_context_task", _perform_framework_context_task.__get__(task_manager))


### PR DESCRIPTION
## Summary
- expand `CodeAnalyzer` patterns to scan Java, C#, Ruby and PHP files
- support language patterns for these file types
- add `quality_suite` task running lint, analysis and tests concurrently
- add plugin to load framework context from config files
- document build commands in new `PROJECT_GUIDE.md`
- mention new features in README and ROADMAP

## Testing
- `pytest -q`
- `pre-commit run --files README.md ROADMAP.md devai/analyzer.py devai/tasks.py PROJECT_GUIDE.md plugins/framework_context.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a0c30034832084fa3860b37c36f3