### PR TITLE
Add CLI memory commands and preference store

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -1,0 +1,28 @@
+# DevAI Command Reference
+
+Este documento descreve os comandos simbólicos disponíveis no DevAI via CLI. Todos eles produzem mensagens simbólicas e estão preparados para integração futura ao painel visual.
+
+## /lembrar <conteúdo> [tipo:<tag>]
+Armazena uma memória manualmente na base vetorial. Opcionalmente é possível definir uma tag de tipo.
+
+Exemplo:
+```bash
+devai lembrar "Evitar variáveis globais" tipo:regra
+```
+
+## /esquecer <termo>
+Desativa memórias relacionadas ao termo. Elas não são removidas fisicamente, apenas marcadas como desativadas.
+
+## /ajustar estilo:<parâmetro> valor:<opção>
+Altera preferências de comportamento da IA. As configurações ficam em `PREFERENCES_STORE.json`.
+
+Exemplo:
+```bash
+devai ajustar estilo:modo_refatoracao valor:seguro
+```
+
+## /rastrear <arquivo|tarefa>
+Exibe o histórico simbólico de decisões e modificações que afetaram o alvo informado.
+
+## /memoria tipo:<tag> [filtro:<texto>]
+Busca memórias armazenadas filtrando por tipo e texto. Possui paginação e a flag `--detalhado` para mostrar informações completas.

--- a/PREFERENCES_STORE.json
+++ b/PREFERENCES_STORE.json
@@ -1,0 +1,5 @@
+{
+  "estilo_prompt": "descritivo",
+  "nivel_explicitacao": "medio",
+  "modo_refatoracao": "minimalista"
+}

--- a/devai/decision_log.py
+++ b/devai/decision_log.py
@@ -13,8 +13,16 @@ except Exception:  # pragma: no cover - optional dependency
 from .config import logger
 
 
-def log_decision(tipo: str, modulo: str, motivo: str, modelo: str, resultado: str, score: str | None = None, fallback: bool | None = None) -> Tuple[str, str]:
-    """Register a decision entry in decision_log.yaml."""
+def log_decision(
+    tipo: str,
+    modulo: str,
+    motivo: str,
+    modelo: str,
+    resultado: str,
+    score: str | None = None,
+    fallback: bool | None = None,
+) -> Tuple[str, str]:
+    """Register a decision entry in ``decision_log.yaml`` and ``decision_log.md``."""
     path = Path("decision_log.yaml")
     data = []
     if path.exists() and yaml is not None:
@@ -40,5 +48,12 @@ def log_decision(tipo: str, modulo: str, motivo: str, modelo: str, resultado: st
     data.append(entry)
     if yaml is not None:
         path.write_text(yaml.safe_dump(data, allow_unicode=True))
+
+    # Also append a short summary in Markdown for quick human inspection
+    md_path = Path("decision_log.md")
+    md_line = f"- {entry['timestamp']} [{entry['id']}] {tipo} {modulo} - {motivo}\n"
+    with md_path.open("a", encoding="utf-8") as f:
+        f.write(md_line)
+
     logger.info("Decisao registrada", id=entry_id, tipo=tipo)
     return entry_id, h

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -84,3 +84,14 @@ def test_search_without_index():
         results = mem.search("fallback")
         assert results
         assert results[0]["content"] == "fallback"
+
+
+def test_deactivate_memories():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = f"{tmp}/mem.sqlite"
+        mem = MemoryManager(db, "dummy", model=None, index=None)
+        mem.save({"type": "note", "content": "secret", "metadata": {}, "tags": []})
+        assert mem.search("secret")
+        count = mem.deactivate_memories("secret")
+        assert count == 1
+        assert not mem.search("secret")


### PR DESCRIPTION
## Summary
- support Markdown logging in `decision_log`
- expand CLI with commands `/lembrar`, `/esquecer`, `/ajustar` and `/rastrear`
- add pagination and detail flags to `/memoria`
- store preferences in new `PREFERENCES_STORE.json`
- allow deactivating memories via `deactivate_memories`
- document command usage in `COMMANDS_REFERENCE.md`
- test memory deactivation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843aebb21cc8320b75803bb4a375c5a