### PR TITLE
Implement user preferences

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -60,6 +60,11 @@ def main():
             else:
                 print("Nenhum resumo disponivel")
             return
+        elif cmd[0] == "preferencia" and len(cmd) > 1:
+            from .feedback import registrar_preferencia
+            registrar_preferencia(" ".join(cmd[1:]))
+            print("Preferência registrada com sucesso")
+            return
 
     print("Por favor, especifique --api ou --cli para iniciar o aplicativo")
 

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -3,7 +3,7 @@ import json
 
 from .config import config, logger
 from .core import CodeMemoryAI
-from .feedback import FeedbackDB
+from .feedback import FeedbackDB, registrar_preferencia
 from .decision_log import log_decision
 from pathlib import Path
 import re
@@ -177,6 +177,10 @@ async def cli_main():
                     Path("PREFERENCES_STORE.json").write_text(json.dumps(prefs, indent=2))
                     log_decision("comando", "ajustar", f"{param}={val}", "cli", "ok")
                     print("Preferência atualizada")
+            elif user_input.startswith("/preferencia "):
+                text = user_input[len("/preferencia "):].strip().strip('"')
+                registrar_preferencia(text)
+                print("Preferência registrada com sucesso")
             elif user_input.startswith("/rastrear "):
                 target = user_input[len("/rastrear "):].strip()
                 print("-- Rastreamento --")

--- a/devai/feedback.py
+++ b/devai/feedback.py
@@ -1,6 +1,10 @@
 import sqlite3
 from datetime import datetime
 from typing import List, Dict
+from pathlib import Path
+import json
+
+PREFS_FILE = Path(__file__).with_name("preferences_store.json")
 
 class FeedbackDB:
     """Simple feedback registry."""
@@ -42,3 +46,26 @@ class FeedbackDB:
             {"file": f, "tag": t, "reason": r, "timestamp": ts}
             for f, t, r, ts in cur.fetchall()
         ]
+
+
+def registrar_preferencia(texto: str) -> None:
+    """Store a style preference in ``preferences_store.json`` avoiding duplicates."""
+    if not PREFS_FILE.exists():
+        PREFS_FILE.write_text(json.dumps({"preferencias": []}, indent=2))
+    data = json.loads(PREFS_FILE.read_text() or "{}")
+    prefs = data.get("preferencias", [])
+    if texto not in prefs:
+        prefs.append(texto)
+    data["preferencias"] = prefs
+    PREFS_FILE.write_text(json.dumps(data, indent=2))
+
+
+def listar_preferencias() -> List[str]:
+    """Return the list of stored preferences."""
+    if not PREFS_FILE.exists():
+        return []
+    try:
+        data = json.loads(PREFS_FILE.read_text() or "{}")
+        return data.get("preferencias", [])
+    except Exception:
+        return []

--- a/devai/preferences_store.json
+++ b/devai/preferences_store.json
@@ -1,0 +1,3 @@
+{
+  "preferencias": []
+}

--- a/devai/prompt_engine.py
+++ b/devai/prompt_engine.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Sequence
 
 from .config import config, logger
+from .feedback import listar_preferencias
 
 SYSTEM_PROMPT_CONTEXT = (
     "Você atua como engenheiro simbólico. "
@@ -61,6 +62,14 @@ def build_cot_prompt(
     logs: str,
 ) -> str:
     """Compose a reasoning prompt with full context."""
+    prefs = listar_preferencias()
+    pref_text = ""
+    if prefs:
+        pref_lines = "\n".join(f"- {p}" for p in prefs)
+        pref_text = (
+            "Estas são as preferências do usuário para estilo de código:\n"
+            f"{pref_lines}\n\n"
+        )
     identity = SYSTEM_PROMPT_CONTEXT
     proj_text, proj_cfg = _load_project_identity()
     mem_text = _format_memories(memories)
@@ -72,7 +81,7 @@ def build_cot_prompt(
         "\nPor favor, forneça um plano de execução, checklist e questione informação faltante." if step_mode else ""
     )
     prompt = (
-        f"{identity}\n{proj_text}\n{mem_text}\n\n{graph_summary}\n\n"
+        f"{pref_text}{identity}\n{proj_text}\n{mem_text}\n\n{graph_summary}\n\n"
         f"Ultimas ações:\n{acts}\n\n"
         f"Logs recentes:\n{logs}\n\nComando do usuário: {command}\n"
         "Antes de gerar código, descreva em 2-3 etapas a lógica da solução. "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,3 +26,18 @@ def test_cli_exit(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Comandos disponíveis" in out
     assert "/ls" in out
+
+
+def test_cli_preferencia(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "CodeMemoryAI", DummyAI)
+    recorded = []
+    monkeypatch.setattr(cli, "registrar_preferencia", lambda t: recorded.append(t))
+
+    async def run():
+        with patch("builtins.input", side_effect=["/preferencia usar x", "/sair"]):
+            await cli.cli_main()
+
+    asyncio.run(run())
+    out = capsys.readouterr().out
+    assert "Preferência registrada com sucesso" in out
+    assert recorded == ["usar x"]

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,0 +1,17 @@
+import json
+import asyncio
+from pathlib import Path
+from devai import feedback
+
+
+def test_registrar_preferencia(tmp_path, monkeypatch):
+    prefs_file = tmp_path / "prefs.json"
+    prefs_file.write_text(json.dumps({"preferencias": []}))
+    monkeypatch.setattr(feedback, "PREFS_FILE", prefs_file)
+    feedback.registrar_preferencia("use aspas simples")
+    feedback.registrar_preferencia("use aspas simples")
+    feedback.registrar_preferencia("evite loops")
+    assert feedback.listar_preferencias() == [
+        "use aspas simples",
+        "evite loops",
+    ]


### PR DESCRIPTION
## Summary
- add JSON store for user preferences under devai/
- allow registering and listing preferences via feedback module
- expose `/preferencia` command in CLI and top-level `preferencia` command
- include preferences when building prompts
- test preference logic and CLI command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d49c21d883208ad2b057ca88e12a