### PR TITLE
Implement failure-driven feedback loop

### DIFF
--- a/devai/feedback.py
+++ b/devai/feedback.py
@@ -69,3 +69,9 @@ def listar_preferencias() -> List[str]:
         return data.get("preferencias", [])
     except Exception:
         return []
+
+
+def registrar_feedback_negativo(arquivo: str, motivo: str) -> None:
+    """Convenience helper to store negative feedback."""
+    db = FeedbackDB()
+    db.add(arquivo, "negativo", motivo)

--- a/devai/learning_engine.py
+++ b/devai/learning_engine.py
@@ -9,7 +9,9 @@ knowledge and ``AIModel`` as the interface to the language model.
 from __future__ import annotations
 
 import asyncio
+import json
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -17,6 +19,36 @@ from .config import logger, config
 from .memory import MemoryManager
 from .ai_model import AIModel
 from .analyzer import CodeAnalyzer
+
+LESSONS_FILE = Path(__file__).with_name("lessons.json")
+
+
+def registrar_licao_negativa(arquivo: str, erro: str) -> None:
+    """Store a negative lesson for later reference."""
+    try:
+        data = json.loads(LESSONS_FILE.read_text()) if LESSONS_FILE.exists() else []
+    except Exception:
+        data = []
+    data.append(
+        {
+            "arquivo": arquivo,
+            "erro": erro,
+            "tipo": "licao_negativa",
+            "timestamp": datetime.now().isoformat(),
+        }
+    )
+    LESSONS_FILE.write_text(json.dumps(data, indent=2))
+
+
+def listar_licoes_negativas(arquivo: str) -> List[str]:
+    """Return negative lessons recorded for a given file."""
+    if not LESSONS_FILE.exists():
+        return []
+    try:
+        items = json.loads(LESSONS_FILE.read_text())
+    except Exception:
+        return []
+    return [i.get("erro", "") for i in items if i.get("arquivo") == arquivo]
 
 
 class LearningEngine:

--- a/devai/prompt_utils.py
+++ b/devai/prompt_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List, Dict, Sequence
 from .prompt_engine import SYSTEM_PROMPT_CONTEXT
+from .learning_engine import listar_licoes_negativas
 
 
 def build_user_query_prompt(query: str, memories: Sequence[Dict], chunks: Sequence[Dict]) -> str:
@@ -31,10 +32,19 @@ def build_analysis_prompt(code: str, issues: Sequence[str]) -> str:
     )
 
 
-def build_refactor_prompt(code: str) -> str:
+def build_refactor_prompt(code: str, file_path: str | None = None) -> str:
     """Prompt asking for a refactored version of the code."""
+    lesson_text = ""
+    if file_path:
+        licoes = listar_licoes_negativas(file_path)
+        if licoes:
+            items = "\n".join(f"- {e}" for e in licoes)
+            lesson_text = (
+                "Atenção: Neste arquivo, os seguintes padrões de erro já ocorreram:\n"
+                f"{items}\nEvite repetir esses problemas.\n"
+            )
     return (
-        f"{SYSTEM_PROMPT_CONTEXT}\nRefatore o código a seguir mantendo a funcionalidade e melhore o estilo:\n"
+        f"{SYSTEM_PROMPT_CONTEXT}\n{lesson_text}Refatore o código a seguir mantendo a funcionalidade e melhore o estilo:\n"
         f"{code}\n### Código refatorado:\nVamos pensar passo a passo antes de responder.\n"
     )
 

--- a/devai/tasks.py
+++ b/devai/tasks.py
@@ -408,7 +408,7 @@ class TaskManager:
             return {"error": str(e)}
 
         from .prompt_utils import build_refactor_prompt
-        prompt = build_refactor_prompt(original)
+        prompt = build_refactor_prompt(original, file_path)
         try:
             suggestion = await self.ai_model.generate(prompt, max_length=len(original) + 200)
         except Exception as e:

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -1,11 +1,24 @@
 from devai.update_manager import UpdateManager
+import devai.update_manager as upd
+
+
+class DummyModel:
+    async def generate(self, prompt, max_length=0):
+        return "retry"
+
+    async def close(self):
+        pass
 
 
 def test_safe_apply_success(tmp_path, monkeypatch):
     file = tmp_path / "f.txt"
     file.write_text("old")
     mgr = UpdateManager()
-    monkeypatch.setattr(mgr, "run_tests", lambda: True)
+    monkeypatch.setattr(
+        mgr,
+        "run_tests",
+        lambda capture_output=False: (True, "") if capture_output else True,
+    )
     result = mgr.safe_apply(file, lambda p: p.write_text("new"))
     assert result
     assert file.read_text() == "new"
@@ -16,7 +29,14 @@ def test_safe_apply_failure(tmp_path, monkeypatch):
     file = tmp_path / "f.txt"
     file.write_text("old")
     mgr = UpdateManager()
-    monkeypatch.setattr(mgr, "run_tests", lambda: False)
+    monkeypatch.setattr(
+        mgr,
+        "run_tests",
+        lambda capture_output=False: (False, "erro") if capture_output else False,
+    )
+    monkeypatch.setattr(upd, "AIModel", lambda: DummyModel())
+    monkeypatch.setattr(upd, "registrar_licao_negativa", lambda a, b: None)
+    monkeypatch.setattr(upd, "registrar_feedback_negativo", lambda a, b: None)
     result = mgr.safe_apply(file, lambda p: p.write_text("new"))
     assert not result
     assert file.read_text() == "old"


### PR DESCRIPTION
## Summary
- integrate automated retry workflow in `UpdateManager`
- store negative lessons via `registrar_licao_negativa`
- expose negative lessons in refactor prompts
- add helper `registrar_feedback_negativo`
- pass file path into refactor prompts
- update unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843dc843b208320ad58e587e4c17b07