### PR TITLE
Implement symbolic deep training mode

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -60,6 +60,11 @@ def main():
             else:
                 print("Nenhum resumo disponivel")
             return
+        elif cmd[0] == "treinamento" and len(cmd) > 1 and cmd[1] == "profundo":
+            from .symbolic_training import run_symbolic_training
+            result = asyncio.run(run_symbolic_training(ai.analyzer, ai.memory, ai.ai_model))
+            print(json.dumps(result, indent=2))
+            return
         elif cmd[0] == "preferencia" and len(cmd) > 1:
             from .feedback import registrar_preferencia
             registrar_preferencia(" ".join(cmd[1:]))

--- a/devai/core.py
+++ b/devai/core.py
@@ -205,6 +205,13 @@ class CodeMemoryAI:
             }
             return summary
 
+        @self.app.post("/symbolic_training")
+        async def symbolic_training(token: str = ""):
+            if not _auth(token):
+                return {"error": "unauthorized"}
+            from .symbolic_training import run_symbolic_training
+            return await run_symbolic_training(self.analyzer, self.memory, self.ai_model)
+
         os.makedirs("static", exist_ok=True)
         self.app.mount("/static", StaticFiles(directory="static"), name="static")
 

--- a/devai/memory.py
+++ b/devai/memory.py
@@ -17,6 +17,9 @@ MEMORY_TYPES = [
     "aprendizado_importado",
     "regra do usuario",
     "licao aprendida",
+    "refatoracao_sugerida",
+    "risco_reincidente",
+    "ponto_critico",
 ]
 
 try:

--- a/devai/symbolic_training.py
+++ b/devai/symbolic_training.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Dict, List
+
+from .config import config, logger
+from .learning_engine import listar_licoes_negativas
+from .memory import MemoryManager
+from .analyzer import CodeAnalyzer
+from .ai_model import AIModel
+
+
+async def run_symbolic_training(
+    analyzer: CodeAnalyzer,
+    memory: MemoryManager,
+    ai_model: AIModel,
+) -> Dict[str, int]:
+    """Execute the symbolic deep training cycle."""
+    await analyzer.scan_app()
+    code_root = Path(config.CODE_ROOT)
+    total_files = 0
+    history_files = 0
+    at_risk = 0
+    suggestions = 0
+    sensitive: List[str] = []
+    patterns: List[str] = []
+    sugg_lines: List[str] = []
+
+    for file_path in code_root.rglob("*.py"):
+        total_files += 1
+        history = listar_licoes_negativas(str(file_path))
+        if history:
+            history_files += 1
+            sensitive.append(f"- {file_path} → [{len(history)} erros anteriores]")
+        try:
+            code = file_path.read_text()
+        except Exception:
+            code = ""
+        meta = {"file": str(file_path)}
+        if history:
+            meta["historico_erros"] = history
+        explain = await ai_model.generate(f"O que esse codigo faz?\n{code}")
+        bad = await ai_model.generate(f"Ha padroes ruins aqui?\n{code}")
+        risk = await ai_model.generate(
+            f"Considerando erros passados {history}, que erro pode se repetir?\n{code}"
+        )
+        improve = await ai_model.generate(
+            f"Como melhorar isso com seguranca? Pense passo a passo.\n{code}"
+        )
+        memory.save(
+            {"type": "symbolic_training", "memory_type": "ponto_critico", "content": explain, "metadata": meta}
+        )
+        memory.save(
+            {"type": "symbolic_training", "memory_type": "risco_reincidente", "content": risk, "metadata": meta}
+        )
+        memory.save(
+            {"type": "symbolic_training", "memory_type": "refatoracao_sugerida", "content": improve, "metadata": meta}
+        )
+        if bad.strip():
+            patterns.append(f"- {bad.strip().splitlines()[0]}")
+        if risk.strip():
+            at_risk += 1
+        if improve.strip():
+            suggestions += 1
+            sugg_lines.append(f"- {improve.strip().splitlines()[0]}")
+        await asyncio.sleep(0)
+
+    report = ["# Relatório de Treinamento Simbólico Profundo", ""]
+    if sensitive:
+        report.append("## Arquivos sensíveis")
+        report.extend(sensitive)
+        report.append("")
+    if patterns:
+        report.append("## Padrões negativos detectados")
+        report.extend(patterns)
+        report.append("")
+    if sugg_lines:
+        report.append("## Sugestões geradas")
+        report.extend(sugg_lines)
+
+    Path(config.LOG_DIR).mkdir(exist_ok=True)
+    Path(config.LOG_DIR, "symbolic_training_report.md").write_text("\n".join(report))
+    logger.info("Relatorio de treinamento salvo", file="symbolic_training_report.md")
+    return {
+        "total_files": total_files,
+        "arquivos_com_erro": history_files,
+        "em_risco": at_risk,
+        "sugestoes": suggestions,
+    }

--- a/static/index.html
+++ b/static/index.html
@@ -30,6 +30,7 @@
     <button id="send">Enviar</button>
     <button id="deep">🔎 Raciocinar</button>
     <button id="investigate">🧠 Analisar Projeto</button>
+    <button id="trainSymbolic">🧠 Treinar com base em erros passados</button>
   </div>
 </div>
 <div id="aiPanel">
@@ -86,6 +87,12 @@ document.getElementById('deep').onclick=()=>send(true);
 document.getElementById('investigate').onclick=async()=>{
   appendConsole('Analisando projeto...');
   const r=await fetch('/deep_analysis');
+  const data=await r.json();
+  document.getElementById('aiOutput').textContent=JSON.stringify(data,null,2);
+};
+document.getElementById('trainSymbolic').onclick=async()=>{
+  appendConsole('Treinando com base em erros passados...');
+  const r=await fetch('/symbolic_training',{method:'POST'});
   const data=await r.json();
   document.getElementById('aiOutput').textContent=JSON.stringify(data,null,2);
 };

--- a/tests/test_symbolic_training.py
+++ b/tests/test_symbolic_training.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+from devai.symbolic_training import run_symbolic_training
+from devai.analyzer import CodeAnalyzer
+from devai.memory import MemoryManager
+from devai.learning_engine import registrar_licao_negativa, LESSONS_FILE
+from devai.config import config
+
+
+class DummyModel:
+    async def generate(self, prompt, max_length=0):
+        if 'padroes ruins' in prompt:
+            return 'try/except generico'
+        if 'Como melhorar' in prompt:
+            return 'Padronizar estrutura'
+        return 'ok'
+
+
+def test_run_symbolic_training(tmp_path, monkeypatch):
+    code_root = tmp_path / 'app'
+    code_root.mkdir()
+    monkeypatch.setattr('devai.learning_engine.LESSONS_FILE', tmp_path / 'lessons.json')
+    for i in range(3):
+        f = code_root / f'f{i}.py'
+        f.write_text('print("hi")')
+        registrar_licao_negativa(str(f), f'erro{i}')
+    monkeypatch.setattr(config, 'CODE_ROOT', str(code_root))
+    log_dir = tmp_path / 'logs'
+    monkeypatch.setattr(config, 'LOG_DIR', str(log_dir))
+    mem = MemoryManager(str(tmp_path / 'mem.sqlite'), 'dummy', model=None, index=None)
+    analyzer = CodeAnalyzer(str(code_root), mem)
+    model = DummyModel()
+
+    async def run():
+        return await run_symbolic_training(analyzer, mem, model)
+
+    result = asyncio.run(run())
+    assert result['total_files'] == 3
+    assert result['arquivos_com_erro'] == 3
+    assert result['sugestoes'] == 3
+    report = Path(log_dir / 'symbolic_training_report.md')
+    assert report.exists()
+


### PR DESCRIPTION
## Summary
- add new memory types
- implement `run_symbolic_training` module
- expose `/symbolic_training` API endpoint
- add CLI command `treinamento profundo`
- update panel with training button
- test symbolic deep training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e27beef48320a388184c5de86db9