### PR TITLE
Implement auto-monitoring system

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -1,5 +1,6 @@
 import asyncio
 import argparse
+import json
 from pathlib import Path
 
 from .config import config
@@ -69,6 +70,11 @@ def main():
             from .feedback import registrar_preferencia
             registrar_preferencia(" ".join(cmd[1:]))
             print("Preferência registrada com sucesso")
+            return
+        elif cmd[0] == "monitorar":
+            from .monitor_engine import auto_monitor_cycle
+            result = asyncio.run(auto_monitor_cycle(ai.analyzer, ai.memory, ai.ai_model))
+            print(json.dumps(result, indent=2))
             return
 
     print("Por favor, especifique --api ou --cli para iniciar o aplicativo")

--- a/devai/core.py
+++ b/devai/core.py
@@ -212,6 +212,12 @@ class CodeMemoryAI:
             from .symbolic_training import run_symbolic_training
             return await run_symbolic_training(self.analyzer, self.memory, self.ai_model)
 
+        @self.app.get("/auto_monitor")
+        async def auto_monitor():
+            from .monitor_engine import auto_monitor_cycle
+            result = await auto_monitor_cycle(self.analyzer, self.memory, self.ai_model)
+            return result
+
         os.makedirs("static", exist_ok=True)
         self.app.mount("/static", StaticFiles(directory="static"), name="static")
 

--- a/devai/monitor_engine.py
+++ b/devai/monitor_engine.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict
+
+from .config import config, logger
+from .memory import MemoryManager
+from .analyzer import CodeAnalyzer
+from .ai_model import AIModel
+from .symbolic_training import run_symbolic_training
+
+
+async def auto_monitor_cycle(
+    analyzer: CodeAnalyzer,
+    memory: MemoryManager,
+    ai_model: AIModel,
+) -> Dict[str, Any]:
+    """Check internal signals and trigger symbolic training if needed."""
+    log_dir = Path(config.LOG_DIR)
+    log_dir.mkdir(exist_ok=True)
+    monitor_log = log_dir / "monitoring_history.md"
+    decision_log = log_dir / "self_triggered_analysis.md"
+    training_report = log_dir / "symbolic_training_report.md"
+
+    now = datetime.now()
+    last_training = datetime.fromtimestamp(0)
+    if training_report.exists():
+        last_training = datetime.fromtimestamp(training_report.stat().st_mtime)
+
+    # Count negative memories in the last 24h
+    day_ago = (now - timedelta(hours=24)).isoformat()
+    cursor = memory.conn.cursor()
+    cursor.execute(
+        "SELECT COUNT(*) FROM memory WHERE memory_type IN ('erro_reincidente','falha') AND created_at >= ?",
+        (day_ago,),
+    )
+    failures = cursor.fetchone()[0]
+
+    # Files changed since last training
+    changed_files = [
+        f
+        for f in Path(config.CODE_ROOT).rglob("*.py")
+        if f.stat().st_mtime > last_training.timestamp()
+    ]
+    new_files = len(changed_files)
+
+    hours_since = (now - last_training).total_seconds() / 3600.0
+
+    reasons = []
+    if failures >= 3:
+        reasons.append(f"{failures} falhas em 24h")
+    if new_files >= 5:
+        reasons.append(f"{new_files} arquivos modificados")
+    if hours_since > 72:
+        reasons.append(f"{int(hours_since)}h sem treinamento")
+
+    triggered = bool(reasons)
+    training_executed = False
+    if triggered:
+        training_executed = True
+        logger.info("Monitor acionou treinamento simbólico")
+        await run_symbolic_training(analyzer, memory, ai_model)
+        decision_log.write_text(
+            f"[{now.isoformat()}] Trigger: {'; '.join(reasons)}\n",
+        )
+        monitor_log.open("a").write(
+            f"[{now.strftime('%Y-%m-%d %H:%M')}] Auto-análise executada: {new_files} arquivos alterados + {failures} falhas = treinamento simbólico disparado\n"
+        )
+    else:
+        monitor_log.open("a").write(
+            f"[{now.strftime('%Y-%m-%d %H:%M')}] Auto-análise executada: {new_files} arquivos alterados + {failures} falhas\n"
+        )
+
+    return {
+        "triggered": triggered,
+        "reason": "; ".join(reasons) if reasons else "criterios nao atingidos",
+        "training_executed": training_executed,
+    }

--- a/static/index.html
+++ b/static/index.html
@@ -31,6 +31,7 @@
     <button id="deep">🔎 Raciocinar</button>
     <button id="investigate">🧠 Analisar Projeto</button>
     <button id="trainSymbolic">🧠 Treinar com base em erros passados</button>
+    <button id="autoMonitor">🧭 Autoavaliação Inteligente</button>
   </div>
 </div>
 <div id="aiPanel">
@@ -93,6 +94,12 @@ document.getElementById('investigate').onclick=async()=>{
 document.getElementById('trainSymbolic').onclick=async()=>{
   appendConsole('Treinando com base em erros passados...');
   const r=await fetch('/symbolic_training',{method:'POST'});
+  const data=await r.json();
+  document.getElementById('aiOutput').textContent=JSON.stringify(data,null,2);
+};
+document.getElementById('autoMonitor').onclick=async()=>{
+  appendConsole('Executando auto monitoramento...');
+  const r=await fetch('/auto_monitor');
   const data=await r.json();
   document.getElementById('aiOutput').textContent=JSON.stringify(data,null,2);
 };

--- a/tests/test_monitor_engine.py
+++ b/tests/test_monitor_engine.py
@@ -1,0 +1,93 @@
+import os
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from devai.monitor_engine import auto_monitor_cycle
+from devai.analyzer import CodeAnalyzer
+from devai.memory import MemoryManager
+from devai.config import config
+
+
+class DummyModel:
+    async def generate(self, prompt, max_length=0):
+        return "ok"
+
+
+def _set_time(path: Path, dt: datetime) -> None:
+    ts = dt.timestamp()
+    os.utime(path, (ts, ts))
+
+
+def test_auto_monitor_no_trigger(tmp_path, monkeypatch):
+    code_root = tmp_path / "app"
+    code_root.mkdir()
+    for i in range(2):
+        f = code_root / f"f{i}.py"
+        f.write_text("print('x')")
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    training = log_dir / "symbolic_training_report.md"
+    training.write_text("old")
+    _set_time(training, datetime.now())
+
+    monkeypatch.setattr(config, "CODE_ROOT", str(code_root))
+    monkeypatch.setattr(config, "LOG_DIR", str(log_dir))
+
+    mem = MemoryManager(str(tmp_path / "mem.sqlite"), "dummy", model=None, index=None)
+    analyzer = CodeAnalyzer(str(code_root), mem)
+    model = DummyModel()
+
+    called = []
+
+    async def fake_run(*a, **k):
+        called.append(True)
+        return {}
+
+    monkeypatch.setattr("devai.monitor_engine.run_symbolic_training", fake_run)
+
+    async def run():
+        return await auto_monitor_cycle(analyzer, mem, model)
+
+    result = asyncio.run(run())
+    assert not result["triggered"]
+    assert not called
+
+
+def test_auto_monitor_trigger(tmp_path, monkeypatch):
+    code_root = tmp_path / "app"
+    code_root.mkdir()
+    for i in range(6):
+        f = code_root / f"f{i}.py"
+        f.write_text("print('x')")
+        _set_time(f, datetime.now())
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    training = log_dir / "symbolic_training_report.md"
+    training.write_text("old")
+    _set_time(training, datetime.now() - timedelta(hours=80))
+
+    monkeypatch.setattr(config, "CODE_ROOT", str(code_root))
+    monkeypatch.setattr(config, "LOG_DIR", str(log_dir))
+
+    mem = MemoryManager(str(tmp_path / "mem.sqlite"), "dummy", model=None, index=None)
+    analyzer = CodeAnalyzer(str(code_root), mem)
+    model = DummyModel()
+
+    for i in range(3):
+        mem.save({"type": "err", "memory_type": "erro_reincidente", "content": "x", "metadata": {}})
+
+    called = []
+
+    async def fake_run(*a, **k):
+        called.append(True)
+        return {}
+
+    monkeypatch.setattr("devai.monitor_engine.run_symbolic_training", fake_run)
+
+    async def run():
+        return await auto_monitor_cycle(analyzer, mem, model)
+
+    result = asyncio.run(run())
+    assert result["triggered"]
+    assert called


### PR DESCRIPTION
## Summary
- add Auto-Monitoramento Simbólico via `monitor_engine.py`
- expose `/auto_monitor` endpoint in the API
- support `devai monitorar` command
- add button in web UI for auto evaluation
- include unit tests for monitor engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e6aff9ec83208a8e8e07cbe03553