### PR TITLE
Add safe API call with response recovery

### DIFF
--- a/devai/core.py
+++ b/devai/core.py
@@ -302,17 +302,23 @@ class CodeMemoryAI:
                 logs,
             )
             if double_check:
-                plan = await self.ai_model.generate(
-                    f"{SYSTEM_PROMPT_CONTEXT}\nElabore um plano de ação para: {query}"
+                plan = await self.ai_model.safe_api_call(
+                    f"{SYSTEM_PROMPT_CONTEXT}\nElabore um plano de ação para: {query}",
+                    config.MAX_CONTEXT_LENGTH,
+                    query,
+                    self.memory,
                 )
-                review = await self.ai_model.generate(
-                    f"{SYSTEM_PROMPT_CONTEXT}\nRevise o plano a seguir e sugira ajustes se necessário:\n{plan}"
+                review = await self.ai_model.safe_api_call(
+                    f"{SYSTEM_PROMPT_CONTEXT}\nRevise o plano a seguir e sugira ajustes se necessário:\n{plan}",
+                    config.MAX_CONTEXT_LENGTH,
+                    plan,
+                    self.memory,
                 )
                 prompt = plan + "\n" + review + "\n" + prompt
             if suggestions:
                 prompt += f"\nSugestao relacionada: {suggestions[0]['content'][:80]}"
             self.reason_stack.append("Prompt preparado")
-            result = await self.ai_model.generate(prompt)
+            result = await self.ai_model.safe_api_call(prompt, config.MAX_CONTEXT_LENGTH, prompt, self.memory)
             self.reason_stack.append("Resposta gerada")
             return result + "\n\nRaciocinio executado:\n" + "\n".join(f"-> {r}" for r in self.reason_stack)
         except Exception as e:

--- a/devai/learning_engine.py
+++ b/devai/learning_engine.py
@@ -71,7 +71,7 @@ class LearningEngine:
         self._call_times.append(time.time())
         self.call_count += 1
         logger.info("Chamada R1", total=self.call_count)
-        return await self.ai_model.generate(prompt, max_length=max_length)
+        return await self.ai_model.safe_api_call(prompt, max_length, prompt, self.memory)
 
     async def learn_from_codebase(self):
         for chunk in self.analyzer.code_chunks.values():

--- a/devai/memory.py
+++ b/devai/memory.py
@@ -20,6 +20,7 @@ MEMORY_TYPES = [
     "refatoracao_sugerida",
     "risco_reincidente",
     "ponto_critico",
+    "resposta_cortada",
 ]
 
 try:
@@ -182,7 +183,15 @@ class MemoryManager:
         return vec
 
     def save(self, entry: Dict, update_feedback: bool = False):
-        entry["metadata"] = json.dumps(entry.get("metadata", {}))
+        meta = entry.get("metadata", {})
+        if entry.get("resposta_recomposta"):
+            if not isinstance(meta, dict):
+                try:
+                    meta = json.loads(str(meta))
+                except Exception:
+                    meta = {"raw": str(meta)}
+            meta["resposta_recomposta"] = True
+        entry["metadata"] = json.dumps(meta)
         content = self._generate_content_for_embedding(entry)
         if self.index is not None:
             embedding_vec = self._get_embedding(content)

--- a/devai/symbolic_training.py
+++ b/devai/symbolic_training.py
@@ -40,13 +40,29 @@ async def run_symbolic_training(
         meta = {"file": str(file_path)}
         if history:
             meta["historico_erros"] = history
-        explain = await ai_model.generate(f"O que esse codigo faz?\n{code}")
-        bad = await ai_model.generate(f"Ha padroes ruins aqui?\n{code}")
-        risk = await ai_model.generate(
-            f"Considerando erros passados {history}, que erro pode se repetir?\n{code}"
+        explain = await ai_model.safe_api_call(
+            f"O que esse codigo faz?\n{code}",
+            config.MAX_CONTEXT_LENGTH,
+            code,
+            memory,
         )
-        improve = await ai_model.generate(
-            f"Como melhorar isso com seguranca? Pense passo a passo.\n{code}"
+        bad = await ai_model.safe_api_call(
+            f"Ha padroes ruins aqui?\n{code}",
+            config.MAX_CONTEXT_LENGTH,
+            code,
+            memory,
+        )
+        risk = await ai_model.safe_api_call(
+            f"Considerando erros passados {history}, que erro pode se repetir?\n{code}",
+            config.MAX_CONTEXT_LENGTH,
+            code,
+            memory,
+        )
+        improve = await ai_model.safe_api_call(
+            f"Como melhorar isso com seguranca? Pense passo a passo.\n{code}",
+            config.MAX_CONTEXT_LENGTH,
+            code,
+            memory,
         )
         memory.save(
             {"type": "symbolic_training", "memory_type": "ponto_critico", "content": explain, "metadata": meta}

--- a/devai/tasks.py
+++ b/devai/tasks.py
@@ -206,7 +206,7 @@ class TaskManager:
                         prompt = build_analysis_prompt(
                             chunk["code"], analysis["issues"] + analysis["rule_findings"]
                         )
-                        suggestion = await self.ai_model.generate(prompt, max_length=200)
+                        suggestion = await self.ai_model.safe_api_call(prompt, 200, prompt, self.memory)
                         analysis["ai_suggestion"] = suggestion.strip()
                     except Exception as e:
                         logger.error("Erro ao gerar sugestão da IA", chunk=chunk["name"], error=str(e))
@@ -410,7 +410,12 @@ class TaskManager:
         from .prompt_utils import build_refactor_prompt
         prompt = build_refactor_prompt(original, file_path)
         try:
-            suggestion = await self.ai_model.generate(prompt, max_length=len(original) + 200)
+            suggestion = await self.ai_model.safe_api_call(
+                prompt,
+                len(original) + 200,
+                prompt,
+                self.memory,
+            )
         except Exception as e:
             logger.error("Erro ao gerar refatoração", error=str(e))
             return {"error": str(e)}
@@ -430,7 +435,12 @@ class TaskManager:
             from .prompt_engine import build_debug_prompt
             debug = build_debug_prompt(out, "", original[:200])
             try:
-                suggestion = await self.ai_model.generate(debug, max_length=len(original) + 200)
+                suggestion = await self.ai_model.safe_api_call(
+                    debug,
+                    len(original) + 200,
+                    debug,
+                    self.memory,
+                )
             except Exception as e:
                 logger.error("Erro no fallback de refatoracao", error=str(e))
                 return {"error": str(e)}

--- a/devai/update_manager.py
+++ b/devai/update_manager.py
@@ -95,7 +95,11 @@ class UpdateManager:
                             "A refatoração anterior falhou nos testes com o seguinte erro:\n"
                             f"{out}\nProponha uma nova solução corrigida, mantendo o objetivo anterior."
                         )
-                        suggestion = await ai.generate(prompt, max_length=len(path.read_text()) + 200)
+                        suggestion = await ai.safe_api_call(
+                            prompt,
+                            len(path.read_text()) + 200,
+                            prompt,
+                        )
                     finally:
                         await ai.close()
                     path.write_text(suggestion)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,6 +25,9 @@ def test_generate_response_short_query(monkeypatch):
         async def generate(self, prompt, max_length=0):
             return "ok"
 
+        async def safe_api_call(self, prompt, max_tokens, context="", memory=None):
+            return "ok"
+
     ai.ai_model = DummyModel()
 
     async def run():

--- a/tests/test_monitor_engine.py
+++ b/tests/test_monitor_engine.py
@@ -13,6 +13,9 @@ class DummyModel:
     async def generate(self, prompt, max_length=0):
         return "ok"
 
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None):
+        return "ok"
+
 
 def _set_time(path: Path, dt: datetime) -> None:
     ts = dt.timestamp()

--- a/tests/test_symbolic_training.py
+++ b/tests/test_symbolic_training.py
@@ -15,6 +15,9 @@ class DummyModel:
             return 'Padronizar estrutura'
         return 'ok'
 
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None):
+        return await self.generate(prompt, max_length=max_tokens)
+
 
 def test_run_symbolic_training(tmp_path, monkeypatch):
     code_root = tmp_path / 'app'

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -89,7 +89,10 @@ def test_auto_refactor(monkeypatch, tmp_path):
             self.called = True
             return True
 
-    tm.ai_model = type("AI", (), {"generate": fake_generate})()
+    async def fake_safe(self, prompt, max_tokens, context="", memory=None):
+        return await fake_generate(self, prompt, max_tokens)
+
+    tm.ai_model = type("AI", (), {"generate": fake_generate, "safe_api_call": fake_safe})()
     import devai.update_manager as upd
     monkeypatch.setattr(upd, "UpdateManager", lambda tests_cmd=None: DummyUpdater())
 

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -6,6 +6,9 @@ class DummyModel:
     async def generate(self, prompt, max_length=0):
         return "retry"
 
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None):
+        return "retry"
+
     async def close(self):
         pass
 


### PR DESCRIPTION
## Summary
- detect incomplete AI responses and rebuild as needed
- persist truncated responses into symbolic memory
- add `safe_api_call` wrapper and apply across modules
- update memory manager to handle `resposta_recomposta`
- adjust tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e98db1508320a3657fe73dc29fd0