### PR TITLE
Improve shadow mode safety and add tests

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -86,7 +86,7 @@ def main():
                 action = "shadow_approved"
             else:
                 action = "shadow_declined" if tests_ok else "shadow_failed"
-            log_simulation(file_path, evaluation["analysis"], action)
+            log_simulation(sim_id, file_path, tests_ok, evaluation["analysis"], action)
             return
         elif cmd[0] == "monitorar":
             from .monitor_engine import auto_monitor_cycle

--- a/devai/core.py
+++ b/devai/core.py
@@ -202,7 +202,7 @@ class CodeMemoryAI:
             tests_ok, test_output = run_tests_in_temp(temp_root)
             evaluation = await evaluate_change_with_ia(diff)
             status = "shadow_failed" if not tests_ok else "shadow_declined"
-            log_simulation(file_path, evaluation["analysis"], status)
+            log_simulation(sim_id, file_path, tests_ok, evaluation["analysis"], status)
             return {
                 "id": sim_id,
                 "diff": diff,

--- a/tests/test_shadow_mode.py
+++ b/tests/test_shadow_mode.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import os
+import pytest
 from devai.shadow_mode import simulate_update
 from devai.config import config
 
@@ -12,5 +14,14 @@ def test_simulate_update_no_apply(tmp_path, monkeypatch):
     assert "+print('new')" in diff
     assert file.read_text() == "print('old')\n"
     assert Path(temp_root).exists()
+
+
+def test_simulate_update_prevents_overwrite(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "CODE_ROOT", str(tmp_path))
+    file = Path(config.CODE_ROOT) / "b.py"
+    file.write_text("print('old')\n")
+    monkeypatch.setattr(os.path, "samefile", lambda a, b: True)
+    with pytest.raises(AssertionError):
+        simulate_update(str(file), "print('x')\n")
 
 

--- a/tests/test_simulation_integrity.py
+++ b/tests/test_simulation_integrity.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import pytest
+
+import devai.shadow_mode as shadow_mode
+from devai.shadow_mode import simulate_update, log_simulation
+from devai.config import config
+
+
+def test_decline_change(tmp_path, monkeypatch):
+    code_root = tmp_path / "app"
+    code_root.mkdir()
+    monkeypatch.setattr(config, "CODE_ROOT", str(code_root))
+    monkeypatch.setattr(config, "LOG_DIR", str(tmp_path / "logs"))
+
+    f = code_root / "m.py"
+    f.write_text("x = 1\n")
+    testf = code_root / "test_m.py"
+    testf.write_text("import m\n\ndef test_x():\n    assert m.x == 1\n")
+
+    diff, temp_root, sim_id = simulate_update(str(f), "x = 2\n")
+    tests_ok, _ = shadow_mode.run_tests_in_temp(temp_root)
+    assert not tests_ok
+    evaluation = {"analysis": "negado"}
+    log_simulation(sim_id, str(f), tests_ok, evaluation["analysis"], "shadow_failed")
+    assert f.read_text() == "x = 1\n"
+    log = Path(config.LOG_DIR) / "simulation_history.md"
+    assert log.exists()
+    text = log.read_text()
+    assert "shadow_failed" in text
+
+
+def test_accept_change(tmp_path, monkeypatch):
+    code_root = tmp_path / "app"
+    code_root.mkdir()
+    monkeypatch.setattr(config, "CODE_ROOT", str(code_root))
+    monkeypatch.setattr(config, "LOG_DIR", str(tmp_path / "logs2"))
+    f = code_root / "n.py"
+    f.write_text("print('old')\n")
+
+    diff, temp_root, sim_id = simulate_update(str(f), "print('new')\n")
+    monkeypatch.setattr(shadow_mode, "run_tests_in_temp", lambda d: (True, ""))
+    tests_ok, _ = shadow_mode.run_tests_in_temp(temp_root)
+    evaluation = {"analysis": "ok"}
+    if tests_ok:
+        f.write_text("print('new')\n")
+        action = "shadow_approved"
+    else:
+        action = "shadow_failed"
+    log_simulation(sim_id, str(f), tests_ok, evaluation["analysis"], action)
+    assert f.read_text() == "print('new')\n"
+    log = Path(config.LOG_DIR) / "simulation_history.md"
+    assert log.exists()
+    text = log.read_text()
+    assert action in text
+


### PR DESCRIPTION
## Summary
- enforce safe temp paths for `simulate_update`
- track simulations in `simulation_history.md` with details
- run tests from copied project directory
- update CLI and API to use new logging
- expand shadow mode tests and add integrity checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843f917ce488320af9e2c654ed87127