### PR TITLE
Improve analyze_deep reasoning output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,3 +45,6 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 
 ## Melhoria pendente – Função /analyze
 - Implementar contexto multi-turno para /analyze via self.conversation_history persistente.
+
+## Melhoria pendente – Análise Explicada (/analyze_deep)
+- Avaliar estabilidade da divisão plano/resposta e ajustar a UI conforme necessário.

--- a/UI_roadmap.md
+++ b/UI_roadmap.md
@@ -1,0 +1,6 @@
+# Planejamento de UI
+
+A área de console agora exibe o plano de raciocínio retornado pelo endpoint
+`/analyze_deep`. A separação visual depende do modelo seguir corretamente a
+marcação `===RESPOSTA===`. Se falhas frequentes ocorrerem, essa divisão poderá
+ser revertida até que a IA tenha comportamento estável.

--- a/command_spec.md
+++ b/command_spec.md
@@ -5,3 +5,10 @@
 - **/resetar**: limpa o histórico de conversa atual.
 
 Esses comandos complementam o comando já implementado `/teste` e serão integrados em versões futuras do DevAI.
+
+Exemplo de uso avançado:
+
+```
+/raciocinar Como melhorar a função processar_dados?
+```
+O assistente irá exibir o plano de raciocínio seguido da resposta final.

--- a/devai/ai_model.py
+++ b/devai/ai_model.py
@@ -133,6 +133,7 @@ class AIModel:
         self,
         prompt: Union[str, Sequence[Mapping[str, str]]],
         max_length: int = config.MAX_CONTEXT_LENGTH,
+        temperature: float = 0.7,
     ) -> str:
         if isinstance(prompt, str):
             key = prompt
@@ -191,7 +192,7 @@ class AIModel:
                 "model": cfg.get("name", config.MODEL_NAME),
                 "messages": messages,
                 "max_tokens": min(max_length, config.MAX_CONTEXT_LENGTH),
-                "temperature": 0.7,
+                "temperature": temperature,
             }
             start = datetime.now()
             try:
@@ -282,6 +283,7 @@ class AIModel:
         max_tokens: int,
         context: str = "",
         memory: "MemoryManager | None" = None,
+        temperature: float = 0.7,
     ) -> str:
         """Call the model ensuring the answer is complete."""
         if isinstance(prompt, str):
@@ -293,7 +295,9 @@ class AIModel:
             available = max_tokens
         attempts = 0
         note = ""
-        response = await self.generate(prompt, max_length=available)
+        response = await self.generate(
+            prompt, max_length=available, temperature=temperature
+        )
         while attempts < 3 and (
             is_response_incomplete(response) or len(response.split()) >= available - 1
         ):
@@ -307,7 +311,9 @@ class AIModel:
                         "content": "Continue exatamente de onde você parou. Não repita partes da resposta anterior.",
                     }
                 ]
-            continuation = await self.generate(cont_prompt, max_length=available)
+            continuation = await self.generate(
+                cont_prompt, max_length=available, temperature=temperature
+            )
             response = rebuild_response(response, continuation)
         if attempts:
             note = "Essa resposta foi reconstruída após corte automático.\n"

--- a/fallback_behavior.md
+++ b/fallback_behavior.md
@@ -1,0 +1,6 @@
+# Comportamento de Fallback para /analyze_deep
+
+Caso o modelo não retorne a marcação `===RESPOSTA===` separando plano de resposta,
+o backend exibirá o texto completo ao usuário e registrará um aviso no log
+`ai_core.log` informando que a separação falhou. Isso garante que a informação
+chegue ao usuário mesmo sem estrutura adequada.

--- a/limitations.md
+++ b/limitations.md
@@ -1,0 +1,6 @@
+# Limitações conhecidas
+
+A configuração de `max_tokens` e `temperature` pode ser ignorada por alguns
+provedores de modelo. Caso isso ocorra, o comportamento do endpoint
+`/analyze_deep` poderá variar em tamanho de resposta. Ainda assim o código
+utiliza 4096 tokens e temperatura 0.2 como valores desejados.

--- a/static/index.html
+++ b/static/index.html
@@ -28,7 +28,7 @@
   <div id="inputArea">
     <textarea id="query" rows="2"></textarea>
     <button id="send">Enviar</button>
-    <button id="deep">🔎 Raciocinar</button>
+    <button id="deep" title="Executa análise profunda com plano passo a passo antes da resposta.">🔎 Análise Explicada</button>
     <button id="investigate">🧠 Analisar Projeto</button>
     <button id="trainSymbolic">🧠 Treinar com base em erros passados</button>
     <button id="autoMonitor">🧭 Autoavaliação Inteligente</button>
@@ -75,8 +75,16 @@ async function send(cot){
   if(!q) return;
   const url=cot?'/analyze_deep':'/analyze';
   const r=await fetch(url+'?'+new URLSearchParams({query:q}),{method:'POST'});
-  const text=await r.text();
-  appendConsole('> '+q+'\n'+text);
+  if(cot){
+    let data;
+    try{ data=await r.json(); }catch(e){ data={plan:'',response:await r.text()}; }
+    if(data.plan) appendConsole('🧠 Plano de Raciocínio:\n'+data.plan);
+    document.getElementById('aiOutput').textContent=data.response;
+    appendConsole('> '+q);
+  }else{
+    const text=await r.text();
+    appendConsole('> '+q+'\n'+text);
+  }
   document.getElementById('query').value='';
 }
 function appendConsole(msg){

--- a/tests/test_analyze_deep_response_structure.py
+++ b/tests/test_analyze_deep_response_structure.py
@@ -1,0 +1,48 @@
+import asyncio
+import types
+from datetime import datetime
+from devai.core import CodeMemoryAI
+
+ai = object.__new__(CodeMemoryAI)
+ai.analyzer = types.SimpleNamespace(
+    graph_summary=lambda: "",
+    code_chunks={},
+    last_analysis_time=datetime.now(),
+)
+
+ai.memory = type("M", (), {"search": lambda self, q, level=None, top_k=5: []})()
+ai.tasks = type(
+    "T",
+    (),
+    {"run_task": lambda self, n: ["ok"], "last_actions": lambda self: []},
+)()
+ai.conversation_history = []
+
+
+class DummyModel:
+    async def safe_api_call(
+        self, messages, max_tokens, context="", memory=None, temperature=0.7
+    ):
+        return "1. Analisar codigo\n2. Sugerir melhoria\n===RESPOSTA===\nUse melhores nomes"
+
+
+ai.ai_model = DummyModel()
+
+
+async def run():
+    return await CodeMemoryAI.generate_response_with_plan(
+        ai, "Como melhorar a função X?"
+    )
+
+
+result = asyncio.run(run())
+
+
+def test_plan_present():
+    assert result["plan"].startswith("1.")
+    assert "2." in result["plan"]
+
+
+def test_separator_removed():
+    assert "===RESPOSTA===" not in result["plan"]
+    assert "===RESPOSTA===" not in result["response"]


### PR DESCRIPTION
## Summary
- split reasoning plan from response for `/analyze_deep`
- support temperature parameter in AI model helper
- display reasoning plan in UI console and rename button
- add docs for new behaviour and limitations
- add regression tests for `/analyze_deep` plan parsing

## Testing
- `pytest -q tests/test_analyze_deep_response_structure.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c4102c0083208b58c999fee979ed