### PR TITLE
Improve project deep analysis output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,3 +48,4 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 
 ## Melhoria pendente – Análise Explicada (/analyze_deep)
 - Avaliar estabilidade da divisão plano/resposta e ajustar a UI conforme necessário.
+\n## Melhoria pendente – Análise de Projeto\n- Aprimorar visualização colorida do relatório gerado.\n- Permitir execução assíncrona do deep_scan_app.

--- a/UI_roadmap.md
+++ b/UI_roadmap.md
@@ -4,3 +4,4 @@ A área de console agora exibe o plano de raciocínio retornado pelo endpoint
 `/analyze_deep`. A separação visual depende do modelo seguir corretamente a
 marcação `===RESPOSTA===`. Se falhas frequentes ocorrerem, essa divisão poderá
 ser revertida até que a IA tenha comportamento estável.
+\n- FUTURE: aplicar destaque colorido ao relatório de /deep_analysis para melhor leitura.

--- a/performance_roadmap.md
+++ b/performance_roadmap.md
@@ -1,0 +1,4 @@
+# Performance Roadmap
+
+- # FUTURE: async scan
+  Implementar execução assíncrona do `deep_scan_app` e armazenamento de status em segundo plano para grandes projetos.

--- a/static/index.html
+++ b/static/index.html
@@ -98,7 +98,7 @@ document.getElementById('investigate').onclick=async()=>{
   appendConsole('Analisando projeto...');
   const r=await fetch('/deep_analysis');
   const data=await r.json();
-  document.getElementById('aiOutput').textContent=JSON.stringify(data,null,2);
+  document.getElementById('aiOutput').textContent=data.report||JSON.stringify(data,null,2);
 };
 document.getElementById('trainSymbolic').onclick=async()=>{
   appendConsole('Treinando com base em erros passados...');

--- a/tests/test_analysis_format.py
+++ b/tests/test_analysis_format.py
@@ -1,0 +1,82 @@
+import asyncio
+from datetime import datetime
+from devai.core import CodeMemoryAI
+import types
+
+class DummyGraph:
+    def __init__(self):
+        self._adj = {'f': {}}
+    def add_node(self, n):
+        self._adj.setdefault(n, {})
+    def out_degree(self, n):
+        return len(self._adj.get(n, {}))
+
+class DummyAnalyzer:
+    def __init__(self):
+        self.code_root = '.'
+        self.code_graph = DummyGraph()
+        self.code_chunks = {
+            'f': {
+                'name': 'f',
+                'file': 'core.py',
+                'code': 'def f(): pass',
+                'complexity': 2,
+                'dependencies': [],
+                'docstring': ''
+            }
+        }
+        self.learned_rules = {}
+        self.last_analysis_time = datetime.now()
+
+    async def deep_scan_app(self):
+        pass
+
+    async def summary_by_module(self):
+        return {'core.py': {'complex_functions': 0, 'todos': 0, 'score': '✅ Estável'}}
+
+class DummyMemory:
+    def save(self, *a, **k):
+        pass
+
+async def run_deep():
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = DummyMemory()
+    ai.analyzer = DummyAnalyzer()
+    ai.ai_model = None
+    ai.learning_engine = None
+    ai.tasks = None
+    ai.log_monitor = None
+    ai.complexity_tracker = None
+    ai.conversation_history = []
+    ai.double_check = False
+
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_get(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = fake_get
+    app.post = fake_get
+    app.mount = lambda *a, **k: None
+    ai.app = app
+
+    CodeMemoryAI._setup_api_routes(ai)
+    deep_fn = record['/deep_analysis']
+    return await deep_fn(token='')
+
+result = asyncio.run(run_deep())
+
+def test_symbols_present():
+    assert '🚩' in result['report']
+    assert '⚠️' in result['report']
+    assert '💡' in result['report']
+
+def test_module_listed():
+    assert 'core.py' in result['modules']
+    assert 'core.py' in result['report']
+
+def test_formatting():
+    assert '🧠 Análise do Projeto' in result['report']
+    assert '\n' in result['report']


### PR DESCRIPTION
## Summary
- enhance `/deep_analysis` endpoint with formatted report
- show module statistics with complexity and TODO counts
- update frontend to display formatted analysis text
- add utilities to summarize modules
- document future async improvement and UI colour highlight
- test that the report contains expected symbols

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c64807b88320a525f5cad91650fe