### PR TITLE
Improve dry_run feature

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,3 +54,9 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - Implementar rastreamento de origem das regras aprendidas
 - Executar treinamento simbólico de forma assíncrona
 - Autoavaliação com rastreamento simbólico por regra
+
+## Melhoria pendente – Aplicação de refatoração simulada
+- Permitir aplicar automaticamente o código sugerido pelo /dry_run preservando backup.
+
+## Melhoria pendente – Análise inteligente do test_output
+- Filtrar falhas individuais e exibir mensagens mais claras no resumo da simulação.

--- a/devai/core.py
+++ b/devai/core.py
@@ -232,6 +232,23 @@ class CodeMemoryAI:
                 "evaluation": evaluation,
             }
 
+        @self.app.post("/apply_refactor")
+        async def apply_refactor(file_path: str, suggested_code: str, token: str = ""):
+            if not _auth(token):
+                return {"error": "unauthorized"}
+            path = Path(file_path)
+            old_lines = path.read_text().splitlines()
+            path.write_text(suggested_code)
+            self.history.record(file_path, "edit", old=old_lines, new=suggested_code.splitlines())
+            self.memory.save({
+                "type": "refatoracao",
+                "memory_type": "refatoracao aprovada",
+                "content": f"Refatoracao aplicada em {file_path}",
+                "metadata": {"arquivo": file_path, "contexto": "dry_run"},
+            })
+            return {"status": "applied"}
+
+
         @self.app.get("/deep_analysis")
         async def deep_analysis(token: str = ""):
             """Run a project wide analysis and return a summary."""

--- a/dry_run_fallbacks.md
+++ b/dry_run_fallbacks.md
@@ -1,0 +1,4 @@
+# Fallbacks para dry_run
+
+- Caso o diff não possa ser aplicado automaticamente, o usuário é orientado a copiar o código gerado manualmente.
+- # FUTURE: aplicar diff colorido em modo de comparação lado a lado.

--- a/static/index.html
+++ b/static/index.html
@@ -10,6 +10,8 @@
   #sidebar { width:220px; background:#f0f0f0; overflow-y:auto; border-right:1px solid #ccc; padding:8px; }
   #main { flex:1; display:flex; flex-direction:column; }
   #editor { flex:1; }
+  .diff .added{color:green;}
+  .diff .removed{color:red;}
   #console { height:150px; background:#111; color:#0f0; overflow-y:auto; font-family:monospace; padding:4px; }
   #inputArea { display:flex; border-top:1px solid #ccc; }
   #inputArea textarea { flex:1; }
@@ -33,11 +35,13 @@
     <button id="trainSymbolic">🧠 Treinar com base em erros passados</button>
     <button id="autoMonitor">🧭 Autoavaliação Inteligente</button>
     <button id="shadowRefactor">🕶️ Simular Refatoração</button>
+    <button id="applyRefactor">✅ Aplicar Refatoração</button>
   </div>
 </div>
 <div id="aiPanel">
   <h3>Painel IA</h3>
   <pre id="aiOutput"></pre>
+  <pre id="diffOutput" class="diff"></pre>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/1.6.2/axios.min.js"></script>
 <script>
@@ -118,11 +122,27 @@ document.getElementById('autoMonitor').onclick=async()=>{
 document.getElementById('shadowRefactor').onclick=async()=>{
   if(!window.currentFile) return;
   const code=editor.getValue();
+  window.lastDryRunCode=code;
   appendConsole('Simulando refatoração...');
   const r=await fetch('/dry_run',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file_path:window.currentFile,suggested_code:code})});
   const data=await r.json();
-  appendConsole(data.diff);
-  document.getElementById('aiOutput').textContent=data.evaluation.analysis;
+  const diffLines=data.diff.split("\n").map(l=>{
+    if(l.startsWith('+')) return '<span class="added">'+l+'</span>';
+    if(l.startsWith('-')) return '<span class="removed">'+l+'</span>';
+    return l;
+  }).join('\n');
+  document.getElementById('diffOutput').innerHTML=diffLines;
+  let summary='';
+  if(data.tests_passed){summary+='✅ Todos os testes passaram.';}
+  else if(!data.test_output){summary+='⚠️ Nenhum teste encontrado no projeto.';}
+  else{summary+='⚠️ Alguns testes falharam.';}
+  document.getElementById('aiOutput').textContent=summary+'\n'+data.evaluation.analysis;
+};
+document.getElementById('applyRefactor').onclick=async()=>{
+  if(!window.currentFile||!window.lastDryRunCode) return;
+  const r=await fetch('/apply_refactor',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file_path:window.currentFile,suggested_code:window.lastDryRunCode})});
+  const d=await r.json();
+  appendConsole(d.status||'applied');
 };
 </script>
 </body>

--- a/tests/test_dry_run_diff_parser.py
+++ b/tests/test_dry_run_diff_parser.py
@@ -1,0 +1,19 @@
+from difflib import unified_diff
+from devai.file_history import FileHistory
+
+
+def test_dry_run_diff_parser(tmp_path):
+    src = tmp_path / "file.py"
+    src.write_text("a\nb\n")
+    new_code = "a\nc\n"
+    diff = "".join(
+        unified_diff(src.read_text().splitlines(keepends=True), new_code.splitlines(keepends=True))
+    )
+    assert "+" in diff and "-" in diff
+    evaluation = {"tests_ok": True}
+    assert "tests_ok" in evaluation
+    history = FileHistory(str(tmp_path / "hist.json"))
+    old_lines = src.read_text().splitlines()
+    src.write_text(new_code)
+    history.record(str(src), "edit", old=old_lines, new=new_code.splitlines())
+    assert src.read_text() == new_code


### PR DESCRIPTION
## Summary
- add new `/apply_refactor` endpoint to apply simulated refactors
- enhance UI to show diff output, summary and apply button
- document dry_run fallbacks
- update roadmap
- add regression test for diff generation

## Testing
- `pre-commit` *(failed: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d2f3deac8320b13d09dc9a63af6a