### PR TITLE
Unify model configuration

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,6 @@
 CODE_ROOT: ./app
 API_PORT: 8000
 LOG_DIR: ./logs
-MODEL_NAME: deepseek/deepseek-r1-0528:free
 MODELS:
   default:
     name: deepseek/deepseek-r1-0528:free

--- a/devai/ai_model.py
+++ b/devai/ai_model.py
@@ -94,7 +94,7 @@ class AIModel:
         self.session = aiohttp.ClientSession()
         self.models = config.MODELS or {
             "default": {
-                "name": config.MODEL_NAME,
+                "name": config.model_name,
                 "api_key": config.OPENROUTER_API_KEY,
                 "url": config.OPENROUTER_URL,
             }
@@ -191,7 +191,7 @@ class AIModel:
                 "Content-Type": "application/json",
             }
             payload = {
-                "model": cfg.get("name", config.MODEL_NAME),
+                "model": cfg.get("name", config.model_name),
                 "messages": messages,
                 "max_tokens": min(max_length, config.MAX_CONTEXT_LENGTH),
                 "temperature": temperature,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,14 @@
+# Configuração do DevAI
+
+Todos os parâmetros de modelo devem ser definidos apenas em `MODELS.default` dentro do `config.yaml`:
+
+```yaml
+MODELS:
+  default:
+    name: deepseek/deepseek-r1-0528:free
+    api_key: ${OPENROUTER_API_KEY}
+    url: https://openrouter.ai/api/v1/chat/completions
+```
+
+O campo `MODEL_NAME` está **obsoleto** e será ignorado futuramente. Utilize `config.model_name` para obter o nome ativo do modelo em código.
+

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import logging
+
+import types
+import config_utils
+from devai.config import Config
+
+
+def _write_cfg(tmp_path: Path, text: str) -> str:
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(text)
+    return str(cfg_file)
+
+
+def test_model_name_from_models(tmp_path, monkeypatch):
+    path = _write_cfg(tmp_path, "MODELS:\n  default:\n    name: mymodel\n")
+    fake_yaml = types.SimpleNamespace(safe_load=lambda f: {"MODELS": {"default": {"name": "mymodel"}}})
+    monkeypatch.setattr(config_utils, "yaml", fake_yaml)
+    cfg = Config(path)
+    assert cfg.model_name == "mymodel"
+
+
+def test_model_name_fallback(tmp_path, monkeypatch):
+    path = _write_cfg(tmp_path, "MODEL_NAME: only\n")
+    fake_yaml = types.SimpleNamespace(safe_load=lambda f: {"MODEL_NAME": "only"})
+    monkeypatch.setattr(config_utils, "yaml", fake_yaml)
+    cfg = Config(path)
+    assert cfg.model_name == "only"
+
+
+def test_warning_on_deprecated(caplog, tmp_path, monkeypatch):
+    path = _write_cfg(
+        tmp_path,
+        "MODEL_NAME: old\nMODELS:\n  default:\n    name: new\n",
+    )
+    fake_yaml = types.SimpleNamespace(
+        safe_load=lambda f: {"MODEL_NAME": "old", "MODELS": {"default": {"name": "new"}}}
+    )
+    monkeypatch.setattr(config_utils, "yaml", fake_yaml)
+    with caplog.at_level(logging.WARNING):
+        cfg = Config(path)
+    assert any("obsoleto" in r.message for r in caplog.records)
+    assert any("divergentes" in r.message for r in caplog.records)
+    assert cfg.model_name == "new"
+


### PR DESCRIPTION
## Summary
- drop deprecated `MODEL_NAME` entry from example config
- warn when `MODEL_NAME` appears in user configs and provide `Config.model_name`
- use new property inside `AIModel`
- document the single source of truth in `docs/CONFIGURATION.md`
- test configuration consistency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e259a4448320bdc7853798dc86fd