### PR TITLE
Add isolated test runner with timeout

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,3 +64,6 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 
 ## Melhoria pendente – Encerramento completo de recursos dinâmicos
 - Encerrar watchers e ciclos longos de forma previsível no método `shutdown`.
+
+## Melhoria pendente – Sandbox de execuções de teste
+- Aplicar sandbox de execução com limite de CPU e memória para testes isolados.

--- a/devai/error_handler.py
+++ b/devai/error_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import subprocess
 from datetime import datetime
 from typing import Callable, Awaitable, TypeVar
 
@@ -41,8 +42,12 @@ def friendly_message(e: Exception) -> str:
     """Map technical errors to friendly messages for the user."""
     if isinstance(e, asyncio.TimeoutError):
         return "⏱️ A IA demorou para responder. Pode estar ocupada."
+    if isinstance(e, subprocess.TimeoutExpired):
+        return "🕒 Testes cancelados por excederem o tempo máximo permitido"
     if isinstance(e, ConnectionError):
         return "📡 Não foi possível conectar à IA. Verifique sua rede ou aguarde reconexão automática."
+    if isinstance(e, MemoryError):
+        return "💥 Testes encerrados por falta de memória"
     if getattr(e, "status", 0) >= 500:
         return "🧱 A IA retornou um erro interno. Isso pode ser temporário."
     return "⚠️ Algo deu errado. Consulte os logs ou tente novamente."

--- a/isolation_fallbacks.md
+++ b/isolation_fallbacks.md
@@ -1,0 +1,6 @@
+# Fallbacks para execuções isoladas
+
+- Sem limite de memória implementado no runner.
+- Sem mecanismo para encerrar watchers externos automaticamente.
+- # FUTURE: implementar sandbox de CPU e memória para testes isolados.
+

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -1,0 +1,20 @@
+import time
+from pathlib import Path
+import devai.shadow_mode as sm
+
+
+def test_run_test_isolated_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(sm.config, "CODE_ROOT", str(tmp_path))
+    (tmp_path / "test_ok.py").write_text("def test_ok():\n    assert True\n")
+    ok, out = sm.run_test_isolated(tmp_path)
+    assert ok
+    assert "1 passed" in out
+
+
+def test_run_test_isolated_timeout(tmp_path, monkeypatch):
+    monkeypatch.setattr(sm.config, "CODE_ROOT", str(tmp_path))
+    (tmp_path / "test_sleep.py").write_text("import time\n\ndef test_sleep():\n    time.sleep(5)\n")
+    ok, out = sm.run_test_isolated(tmp_path, timeout=1)
+    assert not ok
+    assert "Tempo excedido" in out
+


### PR DESCRIPTION
## Summary
- add `run_test_isolated` and update `run_tests_in_temp` using threads and timeout
- expose `run_tests_async` helper for background execution
- map new friendly messages in `error_handler`
- document pending sandbox feature in `ROADMAP`
- include isolation fallbacks note
- test isolated runner in `test_test_runner`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f179a48c832082b9255686af4e6e