### PR TITLE
Add defensive validation and Pydantic models

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - **Dependências opcionais**: oferecer fallback ou mensagens de erro mais amigáveis caso `sentence_transformers` ou `faiss` não estejam instalados. *(implementado)*
 - **Exemplos de configuração**: disponibilizar modelos de `config.yaml` e `tasks.yaml` para facilitar o uso.
 - (adicione novos itens aqui)
+- **Melhoria simbólica** – Validação defensiva aplicada em todas as rotas e edições de arquivo.
 - **Raciocínio progressivo** com modo `step_by_step` configurável no `project_identity.yaml`.
 - **Verificação simbólica de coerência** registrando pontuação e detalhes no `prompt_log.jsonl`.
 - **Tagging automático de memória** para funções novas ou refatoradas (`symbolic_memory_tagger.py`).

--- a/devai/api_schemas.py
+++ b/devai/api_schemas.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+try:
+    from pydantic import BaseModel, Field, validator
+except Exception:  # pragma: no cover - fallback when pydantic is missing
+    from .pydantic_fallback import BaseModel, Field, validator
+
+from .config import config
+
+PROJECT_ROOT = Path(config.CODE_ROOT).resolve()
+
+
+def _validate_path(value: str) -> str:
+    target = (PROJECT_ROOT / value).resolve()
+    if not str(target).startswith(str(PROJECT_ROOT)):
+        raise ValueError("Caminho de arquivo fora do projeto.")
+    return value
+
+
+class FileEditRequest(BaseModel):
+    file: str
+    line: int = Field(..., ge=1)
+    content: str
+
+    _file_validator = validator("file", allow_reuse=True)(_validate_path)
+
+    @validator("content")
+    def _content_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Conteúdo vazio não permitido.")
+        return v
+
+
+class FileCreateRequest(BaseModel):
+    file: str
+    content: str = ""
+
+    _file_validator = validator("file", allow_reuse=True)(_validate_path)
+
+
+class FileDeleteRequest(BaseModel):
+    file: str
+
+    _file_validator = validator("file", allow_reuse=True)(_validate_path)
+
+
+class DirRequest(BaseModel):
+    path: str
+
+    _path_validator = validator("path", allow_reuse=True)(_validate_path)
+
+
+class ApplyRefactorRequest(BaseModel):
+    file_path: str
+    suggested_code: str
+
+    _file_validator = validator("file_path", allow_reuse=True)(_validate_path)
+
+    @validator("suggested_code")
+    def _code_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Código sugerido vazio.")
+        return v

--- a/devai/pydantic_fallback.py
+++ b/devai/pydantic_fallback.py
@@ -1,0 +1,15 @@
+class BaseModel:
+    def __init__(self, **data):
+        for k, v in data.items():
+            setattr(self, k, v)
+
+
+def Field(default=None, **kwargs):
+    return default
+
+
+def validator(*fields, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator

--- a/devai/shadow_mode.py
+++ b/devai/shadow_mode.py
@@ -73,7 +73,11 @@ def log_simulation(
         f.write("### Avaliação IA\n")
         f.write(evaluation + "\n\n")
     logger.info(
-        "Simulação registrada", file=file_path, action=action, id=sim_id, tests=tests_passed
+        "Simulação registrada",
+        file=file_path,
+        action=action,
+        id=sim_id,
+        tests=tests_passed,
     )
 
 
@@ -90,15 +94,21 @@ def run_test_isolated(path: str | Path, timeout: int = 30) -> Tuple[bool, str]:
         )
         return proc.returncode == 0, proc.stdout.decode()
     except subprocess.TimeoutExpired:
-        return False, f"\U0001F6D1 Tempo excedido: os testes demoraram mais de {timeout}s e foram cancelados."
+        return (
+            False,
+            f"\U0001f6d1 Tempo excedido: os testes demoraram mais de {timeout}s e foram cancelados.",
+        )
     except Exception as e:  # pragma: no cover - unexpected errors
-        return False, f"\u26A0\uFE0F Erro ao executar testes: {e}"
+        return False, f"\u26a0\ufe0f Erro ao executar testes: {e}"
 
 
-def run_tests_in_temp(temp_dir: str, timeout: int = 30) -> Tuple[bool, str]:
+def run_tests_in_temp(temp_dir: str | Path, timeout: int = 30) -> Tuple[bool, str]:
     """Execute pytest in a temporary directory copy of the project using isolation."""
-    project_subdir = Path(temp_dir) / Path(config.CODE_ROOT).name
-    cwd = project_subdir if project_subdir.exists() else Path(temp_dir)
+    temp_path = Path(temp_dir)
+    if not temp_path.is_dir():
+        raise ValueError("Diretório temporário inválido para execução de testes.")
+    project_subdir = temp_path / Path(config.CODE_ROOT).name
+    cwd = project_subdir if project_subdir.exists() else temp_path
 
     result: Tuple[bool, str] | None = None
 
@@ -110,13 +120,13 @@ def run_tests_in_temp(temp_dir: str, timeout: int = 30) -> Tuple[bool, str]:
     t.start()
     t.join(timeout + 5)
     if result is None:
-        return False, f"\U0001F6D1 Tempo excedido: os testes demoraram mais de {timeout}s e foram cancelados."
+        return (
+            False,
+            f"\U0001f6d1 Tempo excedido: os testes demoraram mais de {timeout}s e foram cancelados.",
+        )
     return result
 
 
 def run_tests_async(path: str, timeout: int = 30) -> None:
     """Run tests asynchronously in a daemon thread."""
     Thread(target=lambda: run_test_isolated(path, timeout), daemon=True).start()
-
-
-

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,3 +12,7 @@ MODELS:
 
 O campo `MODEL_NAME` está **obsoleto** e será ignorado futuramente. Utilize `config.model_name` para obter o nome ativo do modelo em código.
 
+
+## Limites de acesso
+O DevAI valida caminhos fornecidos nas rotas e funções internas, impedindo leituras ou escritas fora de `CODE_ROOT`. Linhas negativas ou além do tamanho do arquivo resultam em erro.
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,47 @@
+import asyncio
+from pathlib import Path
+import pytest
+
+from devai.analyzer import CodeAnalyzer
+
+
+class DummyMemory:
+    def save(self, entry, update_feedback=False):
+        pass
+
+
+def make_analyzer(tmp_path: Path) -> CodeAnalyzer:
+    root = tmp_path / "app"
+    root.mkdir()
+    return CodeAnalyzer(str(root), DummyMemory())
+
+
+def test_file_outside_root(tmp_path: Path):
+    analyzer = make_analyzer(tmp_path)
+    with pytest.raises(ValueError):
+        asyncio.run(analyzer.create_file("../hack.txt", "x"))
+
+
+def test_negative_line(tmp_path: Path):
+    analyzer = make_analyzer(tmp_path)
+    file = Path(analyzer.code_root) / "f.py"
+    file.write_text("a\nb\n")
+    with pytest.raises(ValueError):
+        asyncio.run(analyzer.edit_line("f.py", -1, "x"))
+
+
+def test_empty_content(tmp_path: Path):
+    analyzer = make_analyzer(tmp_path)
+    file = Path(analyzer.code_root) / "g.py"
+    file.write_text("a\n")
+    with pytest.raises(ValueError):
+        asyncio.run(analyzer.edit_line("g.py", 1, ""))
+
+
+def test_valid_edit(tmp_path: Path):
+    analyzer = make_analyzer(tmp_path)
+    file = Path(analyzer.code_root) / "h.py"
+    file.write_text("old\n")
+    result = asyncio.run(analyzer.edit_line("h.py", 1, "new"))
+    assert result
+    assert file.read_text().strip() == "new"


### PR DESCRIPTION
## Summary
- add Pydantic request schemas with fallback implementation
- validate parameters in file editing and directory operations
- validate path argument for temporary test runs
- expose validated API routes using the new schemas
- add tests for defensive validations
- document new file access limits and roadmap entry

## Testing
- `black devai/api_schemas.py devai/pydantic_fallback.py devai/analyzer.py devai/shadow_mode.py devai/core.py tests/test_validation.py`
- `flake8 devai/api_schemas.py devai/analyzer.py devai/shadow_mode.py devai/core.py tests/test_validation.py` *(fails: command not found)*
- `bandit -r devai` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f4640c1c832096a93af432ca2c54