### PR TITLE
Add symbolic integration tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,7 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - **Automação incremental**: permitir que o projeto evolua com novas funções de forma contínua.
 - **Cache de memória**: reutilizar embeddings e consultas frequentes para acelerar o aprendizado.
 - **Relatórios de cobertura**: integrar ferramentas como `coverage.py` ao processo de testes.
+- **Testes de integração simbólica** validando o ciclo completo IA → sugestão → teste → aplicação.
 - **Análise de segurança**: incorporar `bandit` para detectar vulnerabilidades.
 - **Integração contínua**: rodar tarefas de teste e análise estática automaticamente em um pipeline CI.
 - **Métricas avançadas**: monitorar uso de CPU e memória do assistente.

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,0 +1,10 @@
+# Guia de Testes
+
+Este documento explica como executar e o que validar nos testes.
+
+- `pytest` roda todos os testes unitários e simbólicos.
+- Os testes de integração simulam o ciclo IA → sugestão → teste → aplicação.
+- Rode-os sempre que alterar fluxos principais do DevAI.
+
+Alguns testes estão marcados com `@pytest.mark.skip` pois a memória multi-turno
+não está habilitada. Consulte `testing_fallbacks.md` para detalhes.

--- a/testing_fallbacks.md
+++ b/testing_fallbacks.md
@@ -1,0 +1,5 @@
+# Fallbacks para testes
+
+- Testes que dependem de memória multi-turno ainda não estão ativos.
+- Por isso, `test_memory_multi_turn` fica marcado com `skip` até que a
+  funcionalidade seja implementada.

--- a/tests/test_full_flow.py
+++ b/tests/test_full_flow.py
@@ -1,0 +1,68 @@
+import asyncio
+from pathlib import Path
+import types
+
+import pytest
+
+from devai.shadow_mode import simulate_update, evaluate_change_with_ia, log_simulation
+from devai.update_manager import UpdateManager
+from devai.file_history import FileHistory
+from devai.memory import MemoryManager
+from devai.analyzer import CodeAnalyzer
+from devai.config import config
+
+
+class DummyAI:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None):
+        return "sugestao aprovada"
+
+    async def close(self):
+        pass
+
+
+def test_simulated_update_and_application(tmp_path, monkeypatch):
+    code_root = tmp_path / "app"
+    code_root.mkdir()
+    monkeypatch.setattr(config, "CODE_ROOT", str(code_root))
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(config, "LOG_DIR", str(log_dir))
+
+    file_path = code_root / "mod.py"
+    file_path.write_text("x = 1\n")
+    test_file = code_root / "test_mod.py"
+    test_file.write_text("import mod\n\ndef test_x():\n    assert mod.x == 2\n")
+
+    diff, temp_root, sim_id = simulate_update(str(file_path), "x = 2\n")
+
+    # avoid real subprocess and API calls
+    monkeypatch.setattr("devai.shadow_mode.run_tests_in_temp", lambda d: (True, ""))
+    monkeypatch.setattr("devai.shadow_mode.AIModel", lambda: DummyAI())
+
+    history = FileHistory(str(tmp_path / "hist.json"))
+    mem = MemoryManager(str(tmp_path / "mem.sqlite"), "dummy", model=None, index=None)
+    analyzer = CodeAnalyzer(str(code_root), mem, history)
+
+    async def run_flow():
+        evaluation = await evaluate_change_with_ia(diff)
+        updater = UpdateManager()
+        monkeypatch.setattr(updater, "run_tests", lambda capture_output=False: (True, "") if capture_output else True)
+        success, _ = updater.safe_apply(file_path, lambda p: p.write_text("x = 2\n"), capture_output=True)
+        if success:
+            history.record(str(file_path), "edit", old=["x = 1"], new=["x = 2"])
+            mem.save(
+                {
+                    "type": "refatoracao",
+                    "memory_type": "refatoracao aprovada",
+                    "content": f"Refatoracao aplicada em {file_path}",
+                    "metadata": {"arquivo": str(file_path), "contexto": "dry_run"},
+                }
+            )
+            log_simulation(sim_id, str(file_path), True, evaluation["analysis"], "shadow_approved")
+        return success
+
+    result = asyncio.run(run_flow())
+    assert result
+    assert file_path.read_text() == "x = 2\n"
+    log = Path(config.LOG_DIR) / "simulation_history.md"
+    assert log.exists()
+    assert mem.search("Refatoracao aplicada", memory_type="refatoracao aprovada")

--- a/tests/test_memory_multi_turn.py
+++ b/tests/test_memory_multi_turn.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.mark.skip(reason="Memoria simbolica ainda nao ativada")
+def test_memory_multi_turn():
+    assert True

--- a/tests/test_simulated_conversation.py
+++ b/tests/test_simulated_conversation.py
@@ -1,0 +1,32 @@
+import asyncio
+import types
+from datetime import datetime
+from devai.core import CodeMemoryAI
+
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None):
+        return "ok"
+
+
+def test_simulated_conversation(monkeypatch):
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda q, top_k=5, level=None: [])
+    ai.analyzer = types.SimpleNamespace(
+        graph_summary=lambda: "",
+        code_chunks={},
+        last_analysis_time=datetime.now(),
+    )
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conversation_history = []
+    ai.reason_stack = []
+
+    async def run():
+        first = await ai.generate_response("Como funciona o login?")
+        second = await ai.generate_response("E o logout?")
+        return first, second
+
+    resp1, resp2 = asyncio.run(run())
+    assert "Raciocinio" in resp1
+    assert ai.conversation_history[-2]["content"] == "E o logout?"

--- a/tests/test_symbolic_consistency.py
+++ b/tests/test_symbolic_consistency.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from devai.file_history import FileHistory
+from devai.memory import MemoryManager
+
+
+def test_symbolic_consistency(tmp_path):
+    hist = FileHistory(str(tmp_path / "h.json"))
+    mem = MemoryManager(str(tmp_path / "mem.sqlite"), "dummy", model=None, index=None)
+    hist.record("a.py", "edit", old=["x"], new=["y"])
+    mem.save({
+        "type": "refatoracao",
+        "memory_type": "refatoracao aprovada",
+        "content": "Refatoracao aplicada em a.py",
+        "metadata": {"arquivo": "a.py"},
+    })
+    assert hist.history("a.py")
+    assert mem.search("Refatoracao aplicada", memory_type="refatoracao aprovada")
+    log = Path(tmp_path / "logs")
+    log.mkdir()
+    log_file = log / "simulation_history.md"
+    log_file.write_text("## Simulacao\nA\nA\nA\nA\nshadow_failed\n")
+    text = log_file.read_text()
+    assert "shadow_failed" in text


### PR DESCRIPTION
## Summary
- add symbolic integration tests for update flow, conversations, and memory
- skip placeholder test for future multi-turn memory
- validate symbolic consistency
- document test process and fallbacks
- note symbolic integration tests in roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844faa6bd4483209784793d1ed39175