### PR TITLE
Implement session persistence via localStorage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - **Dependências opcionais**: oferecer fallback ou mensagens de erro mais amigáveis caso `sentence_transformers` ou `faiss` não estejam instalados. *(implementado)*
 - **Exemplos de configuração**: disponibilizar modelos de `config.yaml` e `tasks.yaml` para facilitar o uso.
 - (adicione novos itens aqui)
+- **Persistência de histórico via localStorage**
 - **Sistema simbólico de carregamento para ações demoradas**
 - **Ajuda simbólica para desenvolvedores iniciantes (GUI)**
 - **Onboarding simbólico com fluxo passo a passo**

--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -34,3 +34,11 @@ Resultados retornados em JSON agora são formatados em blocos coloridos no paine
 - **Laranja** mostra sugestões de melhoria.
 - **Vermelho** destaca riscos ou alertas.
 Caso o formato não seja reconhecido, o JSON bruto é exibido com indentação para facilitar a leitura.
+
+## Recuperação automática da sessão
+
+O painel web salva o histórico recente de interações no `localStorage`.
+Ao recarregar a página, o DevAI restaura o conteúdo do painel e do console,
+mostrando a mensagem:
+"🔄 Sessão recuperada – continue de onde parou.". Há também um botão
+**🧹 Limpar Sessão** que apaga os dados salvos e confirma a ação no console.

--- a/static/index.html
+++ b/static/index.html
@@ -59,6 +59,7 @@
   <div id="loading-indicator" class="spinner" style="display:none;">
     <span class="dot">.</span><span class="dot">.</span><span class="dot">.</span> Processando...
   </div>
+  <button id="clearSessionBtn" onclick="clearSession()" style="margin-top:8px;">🧹 Limpar Sessão</button>
 </div>
 <button onclick="showHelpOverlay()" class="help-button">❔ Ajuda</button>
 <div id="help-overlay" class="hidden">
@@ -126,6 +127,7 @@ async function send(cot){
     appendConsole('> '+q+'\n'+text);
   }
   document.getElementById('query').value='';
+  persistUI();
 }
 function appendConsole(msg){
   const c=document.getElementById('console');
@@ -141,6 +143,7 @@ document.getElementById('investigate').onclick=async()=>{
     const r=await fetch('/deep_analysis');
     const data=await r.json();
     displayAIResponseFormatted(data);
+    persistUI();
   }finally{
     hideLoading();
   }
@@ -154,6 +157,7 @@ document.getElementById('trainSymbolic').onclick=async()=>{
     const r=await fetch('/symbolic_training',{method:'POST'});
     const data=await r.json();
     displayAIResponseFormatted(data);
+    persistUI();
   }catch(e){
     out.textContent='Erro durante o treinamento simbólico.';
   }finally{
@@ -168,6 +172,7 @@ document.getElementById('autoMonitor').onclick=async()=>{
     const data=await r.json();
     if(data.logs) appendConsole(data.logs);
     displayAIResponseFormatted(data);
+    persistUI();
   }finally{
     hideLoading();
   }
@@ -192,6 +197,7 @@ document.getElementById('shadowRefactor').onclick=async()=>{
     else if(!data.test_output){summary+='⚠️ Nenhum teste encontrado no projeto.';}
     else{summary+='⚠️ Alguns testes falharam.';}
     document.getElementById('aiOutput').textContent=summary+'\n'+data.evaluation.analysis;
+    persistUI();
   }finally{
     hideLoading();
   }
@@ -203,6 +209,7 @@ document.getElementById('applyRefactor').onclick=async()=>{
     const r=await fetch('/apply_refactor',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file_path:window.currentFile,suggested_code:window.lastDryRunCode})});
     const d=await r.json();
     appendConsole(d.status||'applied');
+    persistUI();
   }finally{
     hideLoading();
   }

--- a/static/script.js
+++ b/static/script.js
@@ -86,3 +86,41 @@ function displayAIResponseFormatted(data){
     panel.appendChild(renderFallbackJSON(data));
   }
 }
+
+const SESSION_KEY='devai_history';
+
+function saveSession(obj){
+  try{localStorage.setItem(SESSION_KEY,JSON.stringify(obj));}catch(e){}
+}
+
+function loadSession(){
+  try{return JSON.parse(localStorage.getItem(SESSION_KEY))||null;}catch(e){return null;}
+}
+
+function persistUI(){
+  const consoleLines=document.getElementById('console').textContent.split('\n').slice(-20).join('\n');
+  saveSession({
+    console:consoleLines,
+    aiOutput:document.getElementById('aiOutput').innerHTML,
+    diffOutput:document.getElementById('diffOutput').innerHTML,
+    ts:Date.now()
+  });
+}
+
+function clearSession(){
+  localStorage.removeItem(SESSION_KEY);
+  document.getElementById('console').textContent='';
+  document.getElementById('aiOutput').innerHTML='';
+  document.getElementById('diffOutput').innerHTML='';
+  appendConsole('🧹 Sessão apagada com sucesso.');
+}
+
+window.addEventListener('load',()=>{
+  const data=loadSession();
+  if(data){
+    document.getElementById('console').textContent=data.console||'';
+    document.getElementById('aiOutput').innerHTML=data.aiOutput||'';
+    document.getElementById('diffOutput').innerHTML=data.diffOutput||'';
+    appendConsole('🔄 Sessão recuperada – continue de onde parou.');
+  }
+});


### PR DESCRIPTION
## Summary
- persist console and AI panel state in browser using localStorage
- add UI button to clear saved session
- document auto-restoration of session
- mention new roadmap item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684513639f2c8320ba2b94995db58b74