### PR TITLE
Add API key validation and UI alert

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - **reason_stack** registrando decisões em tarefas longas.
 - **Proteção de código** via blocos `# <protect>` ... `# </protect>`.
 - **decision_log.yaml** para auditoria de cada ação da IA.
+- **Validação simbólica e notificação de API key**
 - **Modo observador** ativado com `--observer` para apenas registrar insights.
 - **Prompt de metacognição** sugerindo próximos passos a partir do histórico.
 - **Versionamento de respostas** em `history/prompts/` com hash e diff.

--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -42,3 +42,15 @@ Ao recarregar a página, o DevAI restaura o conteúdo do painel e do console,
 mostrando a mensagem:
 "🔄 Sessão recuperada – continue de onde parou.". Há também um botão
 **🧹 Limpar Sessão** que apaga os dados salvos e confirma a ação no console.
+
+## Chave de API ausente ou inválida
+
+Se a variável `OPENROUTER_API_KEY` não estiver configurada ou for rejeitada pelo
+servidor, o painel exibirá:
+
+```
+🚫 Nenhuma chave de API foi detectada. Configure OPENROUTER_API_KEY para habilitar a IA.
+```
+
+Isso evita erros confusos e orienta o usuário a editar o `.env` ou `config.yaml`
+com a chave correta.

--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -19,8 +19,9 @@ def main():
     args = parser.parse_args()
     check_dependencies()
     if not config.OPENROUTER_API_KEY:
-        print("Erro: A variável de ambiente OPENROUTER_API_KEY não está definida")
-        return
+        print(
+            "\u26d4\ufe0f Nenhuma chave OPENROUTER_API_KEY encontrada. Algumas funcionalidades podem não funcionar."
+        )
     if args.api:
         ai = CodeMemoryAI()
         asyncio.run(ai.run())

--- a/devai/ai_model.py
+++ b/devai/ai_model.py
@@ -309,6 +309,10 @@ class AIModel:
         response = await self.generate(
             prompt, max_length=available, temperature=temperature
         )
+        if "401" in response or "Unauthorized" in response:
+            return (
+                "🚫 A chave de API foi rejeitada. Verifique se está correta no config.OPENROUTER_API_KEY."
+            )
         while attempts < 3 and (
             is_response_incomplete(response) or len(response.split()) >= available - 1
         ):

--- a/devai/config.py
+++ b/devai/config.py
@@ -163,6 +163,8 @@ def configure_logging(log_dir: str, aggregator: str = ""):
                 self._l.warning(msg + (" " + " ".join(f"{k}={v}" for k,v in kw.items()) if kw else ""))
             def error(self, msg, **kw):
                 self._l.error(msg + (" " + " ".join(f"{k}={v}" for k,v in kw.items()) if kw else ""))
+            def critical(self, msg, **kw):
+                self._l.critical(msg + (" " + " ".join(f"{k}={v}" for k,v in kw.items()) if kw else ""))
         logger_obj = SimpleLogger(base_logger)
 
     file_handler = logging.handlers.RotatingFileHandler(
@@ -180,5 +182,10 @@ def configure_logging(log_dir: str, aggregator: str = ""):
 
 
 config = Config()
+api_key_missing = not bool(config.OPENROUTER_API_KEY)
 logger = configure_logging(config.LOG_DIR, config.LOG_AGGREGATOR_URL)
+if api_key_missing:
+    logger.critical(
+        "❌ OPENROUTER_API_KEY não configurada. A IA não funcionará corretamente."
+    )
 metrics = Metrics()

--- a/devai/core.py
+++ b/devai/core.py
@@ -20,7 +20,7 @@ from .api_schemas import (
 )
 from fastapi.staticfiles import StaticFiles
 
-from .config import config, logger, metrics
+from .config import config, logger, metrics, api_key_missing
 from .complexity_tracker import ComplexityTracker
 from .memory import MemoryManager
 from .analyzer import CodeAnalyzer
@@ -137,6 +137,7 @@ class CodeMemoryAI:
                 "memory_items": len(self.memory.indexed_ids),
                 "learned_rules": len(self.analyzer.learned_rules),
                 "last_activity": self.analyzer.last_analysis_time.isoformat(),
+                "api_key_missing": api_key_missing,
             }
 
         @self.app.get("/metrics")

--- a/static/script.js
+++ b/static/script.js
@@ -115,7 +115,7 @@ function clearSession(){
   appendConsole('🧹 Sessão apagada com sucesso.');
 }
 
-window.addEventListener('load',()=>{
+window.addEventListener('load',async()=>{
   const data=loadSession();
   if(data){
     document.getElementById('console').textContent=data.console||'';
@@ -123,4 +123,11 @@ window.addEventListener('load',()=>{
     document.getElementById('diffOutput').innerHTML=data.diffOutput||'';
     appendConsole('🔄 Sessão recuperada – continue de onde parou.');
   }
+  try{
+    const r=await fetch('/status');
+    const info=await r.json();
+    if(info.api_key_missing){
+      document.getElementById('aiOutput').textContent='🚫 Nenhuma chave de API foi detectada. Configure OPENROUTER_API_KEY para habilitar a IA.';
+    }
+  }catch(e){}
 });


### PR DESCRIPTION
## Summary
- log missing API key at startup and expose a `api_key_missing` flag
- warn on CLI startup when no key is found
- detect 401 errors and return a friendly message
- expose API key status through `/status` and show notice in the web UI
- document the new behaviour and update roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845186269688320bacb8061c4f21a7f