### PR TITLE
Implement retry and timeout config for AI model

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,3 +13,5 @@ LOCAL_MODEL: ''
 COMPLEXITY_HISTORY: complexity_history.json
 START_MODE: fast  # options: fast, full, custom
 RESCAN_INTERVAL_MINUTES: 15
+MODEL_TIMEOUT: 60  # Tempo máximo de espera por resposta da IA (em segundos)
+

--- a/devai/config.py
+++ b/devai/config.py
@@ -31,6 +31,7 @@ class Config:
     LEARNING_LOOP_INTERVAL: int = 300
     MAX_CONTEXT_LENGTH: int = 160000
     OPENROUTER_URL: str = "https://openrouter.ai/api/v1/chat/completions"
+    MODEL_TIMEOUT: int = 60
     INDEX_FILE: str = "faiss.index"
     INDEX_IDS_FILE: str = "faiss_ids.json"
     NOTIFY_EMAIL: str = os.getenv("NOTIFY_EMAIL", "")

--- a/tests/test_ai_model_retry.py
+++ b/tests/test_ai_model_retry.py
@@ -1,0 +1,46 @@
+import asyncio
+import types
+import logging
+from devai.ai_model import AIModel
+
+class GenCounter:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = 0
+    async def __call__(self, *a, **kw):
+        self.calls += 1
+        resp = self.responses[self.calls - 1]
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+def test_retry_on_timeout_success(caplog):
+    gen = GenCounter([asyncio.TimeoutError(), "ok."])
+    ai = object.__new__(AIModel)
+    ai.generate = gen
+    async def run():
+        return await AIModel.safe_api_call(ai, "q", 50)
+    with caplog.at_level(logging.INFO):
+        result = asyncio.run(run())
+    assert gen.calls == 2
+    assert "⚠️" in result and "ok" in result
+    assert any("Retry attempt triggered" in r.message for r in caplog.records)
+
+def test_retry_timeout_then_failure():
+    gen = GenCounter([asyncio.TimeoutError(), asyncio.TimeoutError()])
+    ai = object.__new__(AIModel)
+    ai.generate = gen
+    async def run():
+        return await AIModel.safe_api_call(ai, "q", 50)
+    result = asyncio.run(run())
+    assert gen.calls == 2
+    assert result.startswith("❌")
+
+def test_timeout_then_unauthorized():
+    gen = GenCounter([asyncio.TimeoutError(), "401 Unauthorized"])
+    ai = object.__new__(AIModel)
+    ai.generate = gen
+    async def run():
+        return await AIModel.safe_api_call(ai, "q", 50)
+    result = asyncio.run(run())
+    assert result.startswith("🚫")


### PR DESCRIPTION
## Summary
- add `MODEL_TIMEOUT` config option to control OpenRouter request timeout
- retry once in `AIModel.safe_api_call` on timeouts or connection drops
- update HTTP request timeout to use the new config
- provide example value in `config.example.yaml`
- test retry behavior for timeouts and invalid keys

## Testing
- `pytest -q`
- `pytest tests/test_ai_model_retry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68451b3a8b508320826244fa805a37c0