### PR TITLE
Improve deep analysis output format

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,4 +14,5 @@ COMPLEXITY_HISTORY: complexity_history.json
 START_MODE: fast  # options: fast, full, custom
 RESCAN_INTERVAL_MINUTES: 15
 MODEL_TIMEOUT: 60  # Tempo máximo de espera por resposta da IA (em segundos)
+SHOW_REASONING_BY_DEFAULT: false
 

--- a/devai/config.py
+++ b/devai/config.py
@@ -39,6 +39,7 @@ class Config:
     COMPLEXITY_HISTORY: str = "complexity_history.json"
     LOG_AGGREGATOR_URL: str = os.getenv("LOG_AGGREGATOR_URL", "")
     DOUBLE_CHECK: bool = False
+    SHOW_REASONING_BY_DEFAULT: bool = False
     START_MODE: str = "fast"  # options: fast, full, custom
     RESCAN_INTERVAL_MINUTES: int = 15  # intervalo mínimo para novas varreduras
 

--- a/devai/core.py
+++ b/devai/core.py
@@ -150,6 +150,7 @@ class CodeMemoryAI:
                 "learned_rules": len(self.analyzer.learned_rules),
                 "last_activity": self.analyzer.last_analysis_time.isoformat(),
                 "api_key_missing": api_key_missing,
+                "show_reasoning_default": config.SHOW_REASONING_BY_DEFAULT,
             }
 
         @self.app.get("/metrics")
@@ -531,11 +532,7 @@ class CodeMemoryAI:
             else:
                 logger.info("multi_turn_fallback", session=session_id)
             self.reason_stack.append("Resposta gerada")
-            return (
-                result
-                + "\n\nRaciocinio executado:\n"
-                + "\n".join(f"-> {r}" for r in self.reason_stack)
-            )
+            return result
         except Exception as e:
             logger.error("Erro ao gerar resposta", error=str(e))
             return f"Erro ao gerar resposta: {str(e)}"
@@ -604,7 +601,16 @@ class CodeMemoryAI:
                 self.conv_handler.append(session_id, "assistant", resp)
             else:
                 logger.info("multi_turn_fallback", session=session_id)
-            return {"plan": plan, "response": resp}
+            trace = (
+                f"\ud83d\udca1 Detalhes t\u00e9cnicos: A IA consultou {len(contextual_memories)} m\u00e9morias anteriores, analisou depend\u00eancias e gerou a resposta abaixo com base no padr\u00e3o simb\u00f3lico aprendido."
+            )
+            return {
+                "plan": plan,
+                "response": resp,
+                "main_response": resp,
+                "reasoning_trace": trace,
+                "mode": "deep",
+            }
         except Exception as e:
             logger.error("Erro ao gerar resposta", error=str(e))
             return {"plan": "", "response": f"Erro ao gerar resposta: {str(e)}"}

--- a/static/index.html
+++ b/static/index.html
@@ -55,6 +55,8 @@
 <div id="aiPanel">
   <h3>Painel IA</h3>
   <pre id="aiOutput"></pre>
+  <button id="toggleReason" style="display:none;" onclick="toggleReasoning()">👁️ Ver raciocínio da IA</button>
+  <pre id="reasoningOutput" class="info-box" style="display:none;"></pre>
   <pre id="diffOutput" class="diff"></pre>
   <div id="loading-indicator" class="spinner" style="display:none;">
     <span class="dot">.</span><span class="dot">.</span><span class="dot">.</span> Processando...
@@ -118,9 +120,17 @@ async function send(cot){
   const r=await fetch(url+'?'+new URLSearchParams({query:q}),{method:'POST'});
   if(cot){
     let data;
-    try{ data=await r.json(); }catch(e){ data={plan:'',response:await r.text()}; }
+    try{ data=await r.json(); }catch(e){ data={}; }
     if(data.plan) appendConsole('🧠 Plano de Raciocínio:\n'+data.plan);
-    document.getElementById('aiOutput').textContent=data.response;
+    document.getElementById('aiOutput').textContent=data.main_response||data.response||'';
+    if(data.reasoning_trace){
+      const msg='🧠 Este trecho explica como a IA chegou na resposta. Pode conter termos técnicos simbólicos usados para autoavaliação e aprendizado.';
+      const el=document.getElementById('reasoningOutput');
+      el.textContent=msg+'\n\n'+data.reasoning_trace;
+      const btn=document.getElementById('toggleReason');
+      btn.style.display='block';
+      el.style.display=showReasoningByDefault?'block':'none';
+    }
     appendConsole('> '+q);
   }else{
     const text=await r.text();

--- a/static/script.js
+++ b/static/script.js
@@ -31,6 +31,12 @@ function hideLoading(){
   }catch(e){}
 }
 
+function toggleReasoning(){
+  const el=document.getElementById('reasoningOutput');
+  if(!el) return;
+  el.style.display=el.style.display==='none'?'block':'none';
+}
+
 function renderStructuredResponse(data){
   const container=document.createElement('div');
   const addSection=(title,list,cls)=>{
@@ -88,6 +94,7 @@ function displayAIResponseFormatted(data){
 }
 
 const SESSION_KEY='devai_history';
+let showReasoningByDefault=false;
 
 function saveSession(obj){
   try{localStorage.setItem(SESSION_KEY,JSON.stringify(obj));}catch(e){}
@@ -102,6 +109,7 @@ function persistUI(){
   saveSession({
     console:consoleLines,
     aiOutput:document.getElementById('aiOutput').innerHTML,
+    reasoning:document.getElementById('reasoningOutput').innerHTML,
     diffOutput:document.getElementById('diffOutput').innerHTML,
     ts:Date.now()
   });
@@ -111,6 +119,7 @@ function clearSession(){
   localStorage.removeItem(SESSION_KEY);
   document.getElementById('console').textContent='';
   document.getElementById('aiOutput').innerHTML='';
+  document.getElementById('reasoningOutput').innerHTML='';
   document.getElementById('diffOutput').innerHTML='';
   appendConsole('🧹 Sessão apagada com sucesso.');
 }
@@ -120,6 +129,7 @@ window.addEventListener('load',async()=>{
   if(data){
     document.getElementById('console').textContent=data.console||'';
     document.getElementById('aiOutput').innerHTML=data.aiOutput||'';
+    document.getElementById('reasoningOutput').innerHTML=data.reasoning||'';
     document.getElementById('diffOutput').innerHTML=data.diffOutput||'';
     appendConsole('🔄 Sessão recuperada – continue de onde parou.');
   }
@@ -129,5 +139,6 @@ window.addEventListener('load',async()=>{
     if(info.api_key_missing){
       document.getElementById('aiOutput').textContent='🚫 Nenhuma chave de API foi detectada. Configure OPENROUTER_API_KEY para habilitar a IA.';
     }
+    if('show_reasoning_default' in info) showReasoningByDefault=info.show_reasoning_default;
   }catch(e){}
 });

--- a/tests/test_analyze_deep_response_structure.py
+++ b/tests/test_analyze_deep_response_structure.py
@@ -48,3 +48,8 @@ def test_plan_present():
 def test_separator_removed():
     assert "===RESPOSTA===" not in result["plan"]
     assert "===RESPOSTA===" not in result["response"]
+
+def test_new_structure_present():
+    assert result["main_response"] == result["response"]
+    assert result["mode"] == "deep"
+    assert "Detalhes" in result["reasoning_trace"]

--- a/tests/test_simulated_conversation.py
+++ b/tests/test_simulated_conversation.py
@@ -30,5 +30,5 @@ def test_simulated_conversation(monkeypatch):
         return first, second
 
     resp1, resp2 = asyncio.run(run())
-    assert "Raciocinio" in resp1
+    assert resp1 == "ok"
     assert ai.conversation_history[-2]["content"] == "E o logout?"


### PR DESCRIPTION
## Summary
- add `SHOW_REASONING_BY_DEFAULT` to configuration
- expose reasoning toggle info in `/status`
- clean up `generate_response` output
- return reasoning trace separately in deep mode
- add reasoning toggle UI with persistence
- adjust tests for new response shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684525526e7c832084ef41393663808a