### PR TITLE
Improve caching and streaming

### DIFF
--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -26,6 +26,7 @@ Todas essas strings ficam definidas em `static/lang.js` para permitir traduçõe
 ## Indicadores de carregamento
 
 Quando uma ação pode levar mais tempo (como aprendizado simbólico ou monitoramento automático), o painel exibe o texto "Processando..." com um pequeno efeito de piscar. Todos os botões são desativados até a conclusão, evitando cliques repetidos.
+Desde esta versão, as respostas da IA são enviadas em tempo real pelo endpoint `/analyze_stream`. O console vai sendo preenchido token a token, oferecendo feedback imediato de que o sistema está ativo.
 
 ## Exibição de resultados complexos
 

--- a/devai/memory.py
+++ b/devai/memory.py
@@ -176,6 +176,7 @@ class MemoryManager:
             return [0.0]
         if text in self.embedding_cache:
             self.embedding_cache.move_to_end(text)
+            logger.info("embedding_cache_hit", text=text[:30])
             return self.embedding_cache[text]
         vec = self.embedding_model.encode(text)
         self.embedding_cache[text] = vec

--- a/performance_roadmap.md
+++ b/performance_roadmap.md
@@ -7,3 +7,4 @@
 - # FUTURE: limitar ciclos por etapa no auto_monitor_cycle
   Garantir que a autoavaliação não cause travamentos.
 - Execução sob demanda do `deep_scan_app` configurada via `START_MODE`.
+- **Pendente**: persistência completa dos vetores de embeddings em disco para evitar recomputações em reinícios.

--- a/prompt_builder_fallbacks.md
+++ b/prompt_builder_fallbacks.md
@@ -4,4 +4,5 @@
 - Um log é registrado com a mensagem:
   "Fallback: prompt completo não foi simplificado por falta de sinal contextual".
 - #future-enhancement:intent-routing: detectar a intenção da pergunta para evitar este fallback.
+- Streaming de resposta é simulado dividindo o texto completo em tokens, pois o modelo atual não suporta `stream=True`.
 

--- a/prompt_engine_async_notes.md
+++ b/prompt_engine_async_notes.md
@@ -1,0 +1,3 @@
+# Notas sobre Paralelismo no Prompt Engine
+
+Paralelismo pós-disparo — estudo em andamento. A versão atual inicia uma tarefa assíncrona de pré-busca enquanto aguarda a resposta do modelo principal, mas ainda não há divisão completa das etapas de geração.

--- a/static/index.html
+++ b/static/index.html
@@ -116,9 +116,9 @@ async function loadFile(f){
 async function send(cot){
   const q=document.getElementById('query').value.trim();
   if(!q) return;
-  const url=cot?'/analyze_deep':'/analyze';
-  const r=await fetch(url+'?'+new URLSearchParams({query:q}),{method:'POST'});
+  const url=cot?'/analyze_deep':'/analyze_stream';
   if(cot){
+    const r=await fetch(url+'?'+new URLSearchParams({query:q}),{method:'POST'});
     let data;
     try{ data=await r.json(); }catch(e){ data={}; }
     if(data.plan) appendConsole('🧠 Plano de Raciocínio:\n'+data.plan);
@@ -133,8 +133,11 @@ async function send(cot){
     }
     appendConsole('> '+q);
   }else{
-    const text=await r.text();
-    appendConsole('> '+q+'\n'+text);
+    appendConsole('> '+q);
+    const out=document.getElementById('console');
+    const es=new EventSource(url+'?'+new URLSearchParams({query:q}));
+    es.onmessage=e=>{out.textContent+=e.data+' ';out.scrollTop=out.scrollHeight;};
+    es.onerror=()=>es.close();
   }
   document.getElementById('query').value='';
   persistUI();


### PR DESCRIPTION
## Summary
- add LRU cache for responses and prefetch task management
- log when embeddings are reused from cache
- document pending embedding persistence
- stream responses via /analyze_stream and update UI
- document async prompt notes and UX changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452a5dae188320a12306996bbc8831