### PR TITLE
Implement session context viewer

### DIFF
--- a/INTERNAL_DOCS.md
+++ b/INTERNAL_DOCS.md
@@ -25,3 +25,4 @@ As memórias ficam disponíveis para novas rodadas de sugestão de código, refo
 ## pending_features
 - memory_extraction_fallback
 - Sincronização automática entre backend e chatHistory local para sessões multi-turn.
+- Em sessões curtas, o botão “🧠 Contexto Atual” pode não retornar memórias ainda.

--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -58,6 +58,13 @@ histórico atual quando desejar começar do zero.
 Com a nova implementação de histórico estruturado, o assistente entende
 referências a perguntas anteriores e mantém o raciocínio encadeado.
 
+## 🔍 Transparência de Contexto
+
+Um botão opcional **🧠 Contexto Atual** exibe as últimas mensagens trocadas,
+memórias simbólicas ativadas e trechos técnicos incluídos no prompt. Use esse
+recurso para auditar o que influenciou a resposta da IA e verificar se há
+avisos de falha de contexto.
+
 ## Chave de API ausente ou inválida
 
 Se a variável `OPENROUTER_API_KEY` não estiver configurada ou for rejeitada pelo

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,4 +15,5 @@ START_MODE: fast  # options: fast, full, custom
 RESCAN_INTERVAL_MINUTES: 15
 MODEL_TIMEOUT: 60  # Tempo máximo de espera por resposta da IA (em segundos)
 SHOW_REASONING_BY_DEFAULT: false
+SHOW_CONTEXT_BUTTON: false
 

--- a/devai/config.py
+++ b/devai/config.py
@@ -40,6 +40,7 @@ class Config:
     LOG_AGGREGATOR_URL: str = os.getenv("LOG_AGGREGATOR_URL", "")
     DOUBLE_CHECK: bool = False
     SHOW_REASONING_BY_DEFAULT: bool = False
+    SHOW_CONTEXT_BUTTON: bool = False
     START_MODE: str = "fast"  # options: fast, full, custom
     RESCAN_INTERVAL_MINUTES: int = 15  # intervalo mínimo para novas varreduras
 

--- a/static/index.html
+++ b/static/index.html
@@ -57,7 +57,9 @@
     <div id="ia-panel" class="chat"></div>
     <pre id="aiOutput"></pre>
     <button id="toggleReason" style="display:none;" onclick="toggleReasoning()">👁️ Ver raciocínio da IA</button>
+    <button id="showContextBtn" style="display:none;" onclick="toggleContext()">🧠 Contexto Atual</button>
     <pre id="reasoningOutput" class="info-box" style="display:none;"></pre>
+    <div id="contextPanel" class="info-box" style="display:none;"></div>
     <pre id="diffOutput" class="diff"></pre>
     <div id="loading-indicator" class="spinner" style="display:none;">
       <span class="dot">.</span><span class="dot">.</span><span class="dot">.</span> Processando...

--- a/static/script.js
+++ b/static/script.js
@@ -37,6 +37,27 @@ function toggleReasoning(){
   el.style.display=el.style.display==='none'?'block':'none';
 }
 
+async function toggleContext(){
+  const panel=document.getElementById('contextPanel');
+  if(!panel) return;
+  if(panel.style.display==='none'){
+    panel.textContent='⌛ carregando...';
+    panel.style.display='block';
+    try{
+      const r=await fetch('/session/context');
+      const data=await r.json();
+      if(data.error){panel.textContent=data.error;return;}
+      const list=p=>p.map(i=>'<li>'+i+'</li>').join('');
+      panel.innerHTML='<h4>🗣️ Últimas mensagens</h4><ul>'+list(data.history_preview)+'</ul>'+
+        '<h4>📌 Memórias Simbólicas Ativadas</h4><ul>'+list(data.symbolic_memories)+'</ul>'+
+        '<h4>🔍 Blocos técnicos usados</h4><ul>'+list(data.logs_or_code)+'</ul>'+
+        (data.warnings.length?'<h4>⚠️ Avisos</h4><p>'+data.warnings.join('<br>')+'</p>':'');
+    }catch(e){panel.textContent='Erro ao carregar contexto';}
+  }else{
+    panel.style.display='none';
+  }
+}
+
 function renderStructuredResponse(data){
   const container=document.createElement('div');
   const addSection=(title,list,cls)=>{
@@ -96,6 +117,7 @@ function displayAIResponseFormatted(data){
 const SESSION_KEY='devai_history';
 const CHAT_KEY='chatHistory';
 let showReasoningByDefault=false;
+let showContextButton=false;
 
 window.chatHistory=[];
 let storageOK=true;
@@ -200,9 +222,12 @@ window.addEventListener('load',async()=>{
       document.getElementById('aiOutput').textContent='🚫 Nenhuma chave de API foi detectada. Configure OPENROUTER_API_KEY para habilitar a IA.';
     }
     if('show_reasoning_default' in info) showReasoningByDefault=info.show_reasoning_default;
+    if('show_context_button' in info) showContextButton=info.show_context_button;
   }catch(e){}
   // syncChatFromBackend(); // habilitar quando endpoint /history estiver disponível
   const btn=document.getElementById('clearHistoryBtn');
   if(btn) btn.onclick=clearChat;
+  const ctx=document.getElementById('showContextBtn');
+  if(ctx) ctx.style.display=showContextButton?'block':'none';
   if(!storageOK) showHistoryWarning();
 });

--- a/tests/test_context_display.py
+++ b/tests/test_context_display.py
@@ -1,0 +1,83 @@
+import asyncio
+import types
+from datetime import datetime
+from devai.core import CodeMemoryAI
+from devai.conversation_handler import ConversationHandler
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None, temperature=0.0):
+        return "ok"
+
+def test_session_context_endpoint(monkeypatch):
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(
+        search=lambda q, top_k=5, level=None, memory_type=None: [
+            {"content": "#preferencia_usuario: Usa função pura", "metadata": {"tag": "#preferencia_usuario"}}
+        ]
+    )
+    ai.analyzer = types.SimpleNamespace(
+        graph_summary=lambda: "grafo", code_chunks={}, last_analysis_time=datetime.now()
+    )
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler()
+    ai.reason_stack = []
+    ai.double_check = False
+    ai.last_context = {"context_blocks": {"logs": "log"}}
+
+    # register fake app
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_get(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = app.post = fake_get
+    app.mount = lambda *a, **k: None
+    ai.app = app
+
+    CodeMemoryAI._setup_api_routes(ai)
+
+    # simulate conversation
+    ai.conv_handler.append("s", "user", "Como funciona?")
+    ai.conv_handler.append("s", "assistant", "Explicação")
+    ai.conv_handler.append("s", "user", "Outra dúvida")
+
+    fn = record['/session/context']
+    result = asyncio.run(fn(session_id='s'))
+    assert "symbolic_memories" in result
+    assert len(result["history_preview"]) > 1
+    assert "#preferencia_usuario" in result["symbolic_memories"][0]
+
+
+def test_session_context_empty(monkeypatch):
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
+    ai.analyzer = types.SimpleNamespace(
+        graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now()
+    )
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler()
+    ai.reason_stack = []
+    ai.double_check = False
+    ai.last_context = {}
+
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_get(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = app.post = fake_get
+    app.mount = lambda *a, **k: None
+    ai.app = app
+
+    CodeMemoryAI._setup_api_routes(ai)
+
+    fn = record['/session/context']
+    result = asyncio.run(fn(session_id='new'))
+    assert "error" in result
+


### PR DESCRIPTION
## Summary
- add `SHOW_CONTEXT_BUTTON` config option
- expose conversation context via `/session/context`
- store last context used for responses
- add optional "🧠 Contexto Atual" button in the UI
- document context transparency and pending feature
- provide tests for session context endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684547934a8483208d8e64ca8c977668