### PR TITLE
Implement session reset endpoint and UI

### DIFF
--- a/INTERNAL_DOCS.md
+++ b/INTERNAL_DOCS.md
@@ -26,3 +26,4 @@ As memórias ficam disponíveis para novas rodadas de sugestão de código, refo
 - memory_extraction_fallback
 - Sincronização automática entre backend e chatHistory local para sessões multi-turn.
 - Em sessões curtas, o botão “🧠 Contexto Atual” pode não retornar memórias ainda.
+- Reset parcial de sessões (limpar conversa, mas manter memórias preferenciais)

--- a/devai/conversation_handler.py
+++ b/devai/conversation_handler.py
@@ -13,6 +13,7 @@ class ConversationHandler:
         self.summary_threshold = summary_threshold
         self.memory = memory
         self.summarizer = DialogSummarizer()
+        self.symbolic_memories: List[str] = []
 
     @staticmethod
     def _estimate_tokens(text: str) -> int:
@@ -55,3 +56,9 @@ class ConversationHandler:
     def reset(self, session_id: str) -> None:
         self.conversation_context[session_id] = []
         logger.info("messages_cleared", session=session_id)
+
+    def clear_session(self, session_id: str = "default") -> None:
+        """Clear conversation history and temporary symbolic memories."""
+        self.conversation_context[session_id] = []
+        self.symbolic_memories = []
+        logger.info("session_reset", session=session_id)

--- a/devai/core.py
+++ b/devai/core.py
@@ -180,6 +180,12 @@ class CodeMemoryAI:
                 self.conversation = self.conv_handler.history("default")
             return {"status": "reset", "session": session_id}
 
+        @self.app.post("/session/reset")
+        async def reset_session():
+            self.conv_handler.clear_session()
+            self.conversation = self.conv_handler.history("default")
+            return {"status": "ok", "message": "Sessão reiniciada com sucesso"}
+
         @self.app.post("/analyze_deep")
         async def analyze_deep(query: str, session_id: str = "default"):
             """Perform a deeper analysis returning plan and answer separately."""

--- a/static/index.html
+++ b/static/index.html
@@ -66,7 +66,7 @@
     </div>
     <div id="history-warning" class="info-box hidden"></div>
     <button id="clearHistoryBtn" style="margin-top:8px;">🧹 Limpar histórico</button>
-    <button id="clearSessionBtn" onclick="clearSession()" style="margin-top:8px;">🧹 Limpar Sessão</button>
+    <button id="reset-session-btn" style="margin-top:8px;">🔄 Nova Conversa</button>
   </div>
 <button onclick="showHelpOverlay()" class="help-button">❔ Ajuda</button>
 <div id="help-overlay" class="hidden">

--- a/static/script.js
+++ b/static/script.js
@@ -195,13 +195,24 @@ function persistUI(){
   });
 }
 
-function clearSession(){
+function clearUIConversation(){
   localStorage.removeItem(SESSION_KEY);
+  clearChat();
   document.getElementById('console').textContent='';
   document.getElementById('aiOutput').innerHTML='';
   document.getElementById('reasoningOutput').innerHTML='';
   document.getElementById('diffOutput').innerHTML='';
-  appendConsole('🧹 Sessão apagada com sucesso.');
+}
+
+function addSystemMessage(msg){
+  addChat('system', msg);
+}
+
+async function resetSession(){
+  await fetch('/session/reset', {method:'POST'});
+  clearUIConversation();
+  try{localStorage.removeItem(CHAT_KEY);}catch(e){}
+  addSystemMessage('✅ Sessão reiniciada com sucesso.');
 }
 
 window.addEventListener('load',async()=>{
@@ -227,6 +238,8 @@ window.addEventListener('load',async()=>{
   // syncChatFromBackend(); // habilitar quando endpoint /history estiver disponível
   const btn=document.getElementById('clearHistoryBtn');
   if(btn) btn.onclick=clearChat;
+  const reset=document.getElementById('reset-session-btn');
+  if(reset) reset.onclick=resetSession;
   const ctx=document.getElementById('showContextBtn');
   if(ctx) ctx.style.display=showContextButton?'block':'none';
   if(!storageOK) showHistoryWarning();

--- a/tests/test_session_reset.py
+++ b/tests/test_session_reset.py
@@ -1,0 +1,7 @@
+from devai.conversation_handler import ConversationHandler
+
+def test_reset_session_clears_conversation():
+    handler = ConversationHandler()
+    handler.conversation_context["default"] = [{"role": "user", "content": "Oi"}]
+    handler.clear_session()
+    assert handler.conversation_context["default"] == []


### PR DESCRIPTION
## Summary
- add `clear_session` method to `ConversationHandler`
- expose `/session/reset` API route
- add new reset button to UI and hook up script
- document pending feature in `INTERNAL_DOCS`
- test session reset logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454a93637483208909c4cb6dfa46c9