### PR TITLE
Add dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENROUTER_API_KEY=your_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ logs/
 *.pyo
 **/__pycache__/
 prompt_log.jsonl
+.env

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ API_PORT: 8000
 API_SECRET: "sua-chave"
 ```
 
-2. Defina a variável de ambiente `OPENROUTER_API_KEY` com sua chave de acesso.
+2. Crie um arquivo `.env` com `OPENROUTER_API_KEY=<sua chave>` ou defina essa
+   variável diretamente no ambiente. O DevAI carrega esse arquivo
+   automaticamente se o pacote `python-dotenv` estiver instalado.
 
 3. Instale as dependências do projeto para habilitar a comunicação real com o OpenRouter:
 

--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -75,4 +75,5 @@ servidor, o painel exibirá:
 ```
 
 Isso evita erros confusos e orienta o usuário a editar o `.env` ou `config.yaml`
-com a chave correta.
+com a chave correta. O arquivo `.env` é carregado automaticamente caso o
+pacote `python-dotenv` esteja instalado.

--- a/devai/config.py
+++ b/devai/config.py
@@ -3,6 +3,12 @@ import logging
 import logging.handlers
 from dataclasses import dataclass, field, fields, MISSING
 from typing import Dict, Any
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+    load_dotenv()
+except Exception:
+    pass
 try:
     import psutil  # type: ignore
 except Exception:  # pragma: no cover - optional dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ uvicorn = "*"
 aiofiles = "*"
 aiohttp = "*"
 structlog = "*"
+python-dotenv = "*"
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ transformers
 psutil
 PyYAML
 PyJWT
+python-dotenv


### PR DESCRIPTION
## Summary
- add `python-dotenv` dependency
- automatically load `.env` in `Config`
- document `.env` usage in README and UX guide
- provide `.env.example` and ignore real `.env`

## Testing
- `pytest -q`
- `flake8 devai` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d7303b4c8320aad57bafb4ba8a47