### PR TITLE
Activate conversation memory saving

### DIFF
--- a/devai/core.py
+++ b/devai/core.py
@@ -61,7 +61,7 @@ class CodeMemoryAI:
         self.response_cache: "OrderedDict[str, Dict]" = OrderedDict()
         self.response_cache_size = 32
         # Gerencia o histórico de cada sessão de conversa
-        self.conv_handler = ConversationHandler()
+        self.conv_handler = ConversationHandler(memory=self.memory)
         self.conversation: List[Dict[str, str]] = self.conv_handler.history(
             "default"
         )

--- a/tests/test_analysis_format.py
+++ b/tests/test_analysis_format.py
@@ -48,7 +48,7 @@ async def run_deep():
     ai.tasks = None
     ai.log_monitor = None
     ai.complexity_tracker = None
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.conversation_history = []
     ai.double_check = False
 

--- a/tests/test_analyze_deep_response_structure.py
+++ b/tests/test_analyze_deep_response_structure.py
@@ -17,7 +17,7 @@ ai.tasks = type(
     (),
     {"run_task": lambda self, n: ["ok"], "last_actions": lambda self: []},
 )()
-ai.conv_handler = ConversationHandler()
+ai.conv_handler = ConversationHandler(memory=ai.memory)
 ai.conversation_history = []
 
 

--- a/tests/test_context_display.py
+++ b/tests/test_context_display.py
@@ -20,7 +20,7 @@ def test_session_context_endpoint(monkeypatch):
     )
     ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
     ai.ai_model = DummyModel()
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.reason_stack = []
     ai.double_check = False
     ai.last_context = {"context_blocks": {"logs": "log"}}
@@ -59,7 +59,7 @@ def test_session_context_empty(monkeypatch):
     )
     ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
     ai.ai_model = DummyModel()
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.reason_stack = []
     ai.double_check = False
     ai.last_context = {}

--- a/tests/test_conversation_context.py
+++ b/tests/test_conversation_context.py
@@ -19,7 +19,7 @@ def test_conversation_context():
     )
     ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
     ai.ai_model = DummyModel()
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.reason_stack = []
     ai.double_check = False
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,7 +32,7 @@ def test_infer_return_type():
 def test_generate_response_short_query(monkeypatch):
     ai.memory = type("M", (), {"search": lambda self, q, level=None, top_k=5: []})()
     ai._find_relevant_code = lambda q: []
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.conversation_history = []
     ai.tasks = type(
         "T",
@@ -61,7 +61,7 @@ def test_generate_response_short_query(monkeypatch):
 
 def test_reset_command(monkeypatch):
     ai.memory = type("M", (), {"search": lambda self, q, level=None, top_k=5: []})()
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.conversation_history = []
     ai.tasks = type(
         "T",
@@ -90,7 +90,7 @@ def test_reset_command(monkeypatch):
 
 def test_conversation_history(monkeypatch):
     ai.memory = type("M", (), {"search": lambda self, q, level=None, top_k=5: []})()
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.conversation_history = []
     ai.tasks = type(
         "T",

--- a/tests/test_dialog_cohesion.py
+++ b/tests/test_dialog_cohesion.py
@@ -26,7 +26,7 @@ def test_multi_turn_cohesion():
     )
     ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
     ai.ai_model = DummyModel()
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.reason_stack = []
     ai.double_check = False
 

--- a/tests/test_memory_multi_turn.py
+++ b/tests/test_memory_multi_turn.py
@@ -1,5 +1,18 @@
-import pytest
+from devai.conversation_handler import ConversationHandler
 
-@pytest.mark.skip(reason="Memoria simbolica ainda nao ativada")
+
+class DummyMemory:
+    def __init__(self):
+        self.saved = []
+
+    def save(self, item):
+        self.saved.append(item)
+
+
 def test_memory_multi_turn():
-    assert True
+    mem = DummyMemory()
+    handler = ConversationHandler(max_history=5, summary_threshold=2, memory=mem)
+    handler.append("s", "user", "Prefiro usar funcoes puras")
+    handler.append("s", "assistant", "Ok")
+    assert mem.saved
+    assert mem.saved[0]["memory_type"] == "dialog_summary"

--- a/tests/test_simulated_conversation.py
+++ b/tests/test_simulated_conversation.py
@@ -20,7 +20,7 @@ def test_simulated_conversation(monkeypatch):
     )
     ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
     ai.ai_model = DummyModel()
-    ai.conv_handler = ConversationHandler()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.conversation_history = []
     ai.reason_stack = []
 


### PR DESCRIPTION
## Summary
- wire up ConversationHandler with MemoryManager
- update tests to pass memory to ConversationHandler
- enable multi-turn memory test now that symbolic memory works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dc464fe0832096a7d3c9c7412b9d