### PR TITLE
Implement sandbox container execution

### DIFF
--- a/devai/sandbox.py
+++ b/devai/sandbox.py
@@ -9,8 +9,28 @@ class Sandbox:
         self.image = image
 
     def run(self, command: List[str], timeout: int = 30) -> str:
-        """Run a command inside a container.
+        """Run a command inside a container using Docker.
 
-        TODO: integrate with Docker/Podman for real isolation.
+        Parameters
+        ----------
+        command:
+            Command and arguments to execute inside the container.
+        timeout:
+            Maximum time in seconds to allow the command to run.
+
+        Returns
+        -------
+        str
+            Captured standard output from the command.
         """
-        raise NotImplementedError("Sandbox execution not implemented yet")
+        docker_cmd = ["docker", "run", "--rm", self.image, *command]
+        try:
+            proc = subprocess.run(
+                docker_cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return proc.stdout
+        except subprocess.TimeoutExpired as e:
+            raise TimeoutError(f"Command timed out after {timeout}s") from e

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,8 +1,34 @@
+import subprocess
 import pytest
 from devai import sandbox
 
 
-def test_run_not_implemented():
+def test_run_executes(monkeypatch):
+    sb = sandbox.Sandbox("img")
+
+    captured = {}
+
+    class DummyResult:
+        stdout = "ok"
+
+    def fake_run(cmd, capture_output, text, timeout):
+        captured["cmd"] = cmd
+        captured["timeout"] = timeout
+        return DummyResult()
+
+    monkeypatch.setattr(sandbox.subprocess, "run", fake_run)
+    out = sb.run(["echo", "hi"], timeout=5)
+    assert out == "ok"
+    assert captured["cmd"] == ["docker", "run", "--rm", "img", "echo", "hi"]
+    assert captured["timeout"] == 5
+
+
+def test_run_timeout(monkeypatch):
     sb = sandbox.Sandbox()
-    with pytest.raises(NotImplementedError):
-        sb.run(["echo", "hi"])
+
+    def fake_run(cmd, capture_output, text, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(sandbox.subprocess, "run", fake_run)
+    with pytest.raises(TimeoutError):
+        sb.run(["sleep", "2"], timeout=1)


### PR DESCRIPTION
## Summary
- implement container execution in `sandbox.Sandbox.run`
- add tests for container run and timeout behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e0d1e8748320b2124f7273b83248