### PR TITLE
Improve task tracking and shutdown flow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,148 @@
+import sys
+import types
+
+if 'networkx' not in sys.modules:
+    class DiGraph:
+        def __init__(self):
+            self._adj = {}
+        def add_node(self, n):
+            self._adj.setdefault(n, set())
+        def add_edge(self, u, v):
+            self.add_node(u)
+            self.add_node(v)
+            self._adj[u].add(v)
+        def nodes(self, data=False):
+            return list(self._adj.keys()) if not data else [(n, {}) for n in self._adj]
+        def edges(self):
+            return [(u, v) for u, vs in self._adj.items() for v in vs]
+        def successors(self, n):
+            return list(self._adj.get(n, []))
+        def number_of_edges(self):
+            return sum(len(v) for v in self._adj.values())
+    def descendants(graph, node):
+        seen = set()
+        stack = list(graph._adj.get(node, []))
+        while stack:
+            cur = stack.pop()
+            if cur not in seen:
+                seen.add(cur)
+                stack.extend(graph._adj.get(cur, []))
+        return seen
+    sys.modules['networkx'] = types.SimpleNamespace(DiGraph=DiGraph, descendants=descendants)
+
+if 'fastapi' not in sys.modules:
+    class FastAPI:
+        def __init__(self, *a, **k):
+            pass
+        def get(self, path):
+            def decorator(fn):
+                return fn
+            return decorator
+        def post(self, path):
+            def decorator(fn):
+                return fn
+            return decorator
+        def mount(self, *a, **k):
+            pass
+
+    class StaticFiles:
+        def __init__(self, *a, **k):
+            pass
+
+    class StreamingResponse:
+        def __init__(self, content, media_type=None):
+            self.content = content
+            self.media_type = media_type
+
+    fastapi_stub = types.ModuleType('fastapi')
+    staticfiles_module = types.ModuleType('fastapi.staticfiles')
+    staticfiles_module.StaticFiles = StaticFiles
+    responses_module = types.ModuleType('fastapi.responses')
+    responses_module.StreamingResponse = StreamingResponse
+    fastapi_stub.FastAPI = FastAPI
+    fastapi_stub.staticfiles = staticfiles_module
+    fastapi_stub.responses = responses_module
+    sys.modules['fastapi'] = fastapi_stub
+    sys.modules['fastapi.staticfiles'] = staticfiles_module
+    sys.modules['fastapi.responses'] = responses_module
+
+if 'uvicorn' not in sys.modules:
+    class Config:
+        def __init__(self, *a, **k):
+            pass
+
+    class Server:
+        def __init__(self, config):
+            self.config = config
+        async def serve(self):
+            pass
+
+    uvicorn_stub = types.ModuleType('uvicorn')
+    uvicorn_stub.Config = Config
+    uvicorn_stub.Server = Server
+    sys.modules['uvicorn'] = uvicorn_stub
+
+if 'aiohttp' not in sys.modules:
+    class ClientSession:
+        async def post(self, *a, **k):
+            class Resp:
+                async def json(self):
+                    return {}
+                async def text(self):
+                    return ""
+            return Resp()
+        async def close(self):
+            pass
+
+    class ClientTimeout:
+        def __init__(self, *a, **k):
+            pass
+
+    aiohttp_stub = types.ModuleType('aiohttp')
+    aiohttp_stub.ClientSession = ClientSession
+    aiohttp_stub.ClientTimeout = ClientTimeout
+    aiohttp_stub.ClientError = Exception
+    aiohttp_stub.ClientConnectionError = Exception
+    sys.modules['aiohttp'] = aiohttp_stub
+
+if 'aiofiles' not in sys.modules:
+    import os
+    class _AIOFile:
+        def __init__(self, path, mode='r'):
+            self._f = open(path, mode)
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *exc):
+            self._f.close()
+        async def read(self):
+            return self._f.read()
+        async def readlines(self):
+            return self._f.readlines()
+        async def write(self, data):
+            self._f.write(data)
+
+    aiofiles_stub = types.ModuleType('aiofiles')
+    aiofiles_stub.open = lambda path, mode='r': _AIOFile(path, mode)
+    aiofiles_os = types.ModuleType('aiofiles.os')
+    async def makedirs(path, exist_ok=False):
+        os.makedirs(path, exist_ok=exist_ok)
+    aiofiles_os.makedirs = makedirs
+    aiofiles_stub.os = aiofiles_os
+    sys.modules['aiofiles'] = aiofiles_stub
+    sys.modules['aiofiles.os'] = aiofiles_os
+
+if 'sklearn' not in sys.modules:
+    class TF:
+        def fit_transform(self, *a, **k):
+            return []
+        def get_feature_names_out(self):
+            return []
+    sklearn_stub = types.ModuleType('sklearn')
+    fe = types.ModuleType('sklearn.feature_extraction')
+    text = types.ModuleType('sklearn.feature_extraction.text')
+    text.TfidfVectorizer = TF
+    fe.text = text
+    sklearn_stub.feature_extraction = fe
+    sys.modules['sklearn'] = sklearn_stub
+    sys.modules['sklearn.feature_extraction'] = fe
+    sys.modules['sklearn.feature_extraction.text'] = text

--- a/tests/test_background_integration.py
+++ b/tests/test_background_integration.py
@@ -1,0 +1,92 @@
+import asyncio
+import types
+from datetime import datetime
+import devai.metacognition as metacog
+from devai.core import CodeMemoryAI
+from devai.config import config
+from devai.conversation_handler import ConversationHandler
+
+events = []
+
+class DummyAnalyzer:
+    def __init__(self):
+        self.code_chunks = {}
+        self.last_analysis_time = datetime.now()
+
+    async def deep_scan_app(self):
+        try:
+            while True:
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            events.append('scan_cancel')
+            raise
+
+    async def watch_app_directory(self):
+        try:
+            while True:
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            events.append('watch_cancel')
+            raise
+
+    def summary_by_module(self):
+        return {}
+
+
+class DummyLogMonitor:
+    async def monitor_logs(self):
+        try:
+            while True:
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            events.append('logs_cancel')
+            raise
+
+
+class DummyMeta:
+    def __init__(self, memory=None):
+        pass
+
+    async def run(self):
+        try:
+            while True:
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            events.append('meta_cancel')
+            raise
+
+
+def dummy_learning():
+    async def _loop():
+        try:
+            while True:
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            events.append('learn_cancel')
+            raise
+    return _loop()
+
+
+def test_background_tasks_shutdown(monkeypatch):
+    global events
+    events = []
+    monkeypatch.setattr(config, 'START_MODE', 'full')
+    monkeypatch.setattr(config, 'OPERATING_MODE', 'standard', raising=False)
+    monkeypatch.setattr(metacog, 'MetacognitionLoop', DummyMeta)
+
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.analyzer = DummyAnalyzer()
+    ai.log_monitor = DummyLogMonitor()
+    ai.background_tasks = {}
+    ai._learning_loop = dummy_learning
+
+    async def run():
+        CodeMemoryAI._start_background_tasks(ai)
+        await asyncio.sleep(0.2)
+        await CodeMemoryAI.shutdown(ai)
+    asyncio.run(run())
+
+    assert not ai.background_tasks
+    assert all(ev in events for ev in ['learn_cancel', 'logs_cancel', 'meta_cancel', 'scan_cancel', 'watch_cancel'])

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -6,7 +6,7 @@ from devai.core import CodeMemoryAI
 def test_shutdown_closes_session(caplog):
     ai = object.__new__(CodeMemoryAI)
     ai.ai_model = CodeMemoryAI.__init__.__globals__["AIModel"]()  # create real AIModel
-    ai.background_tasks = set()
+    ai.background_tasks = {}
     with caplog.at_level(logging.INFO):
         asyncio.run(CodeMemoryAI.shutdown(ai))
     assert getattr(ai.ai_model.session, "closed", True)

--- a/tests/test_startup_mode.py
+++ b/tests/test_startup_mode.py
@@ -47,7 +47,7 @@ def test_startup_fast(monkeypatch):
     class DummyTask:
         def add_done_callback(self, fn):
             pass
-    def fake_create_task(coro):
+    def fake_create_task(coro, *a, **k):
         tasks.append(coro)
         coro.close()
         return DummyTask()
@@ -58,7 +58,7 @@ def test_startup_fast(monkeypatch):
     ai.memory = DummyMemory()
     ai.analyzer = DummyAnalyzer()
     ai.log_monitor = DummyLogMonitor()
-    ai.background_tasks = set()
+    ai.background_tasks = {}
     ai._learning_loop = lambda: dummy_coroutine('learn')
 
     CodeMemoryAI._start_background_tasks(ai)


### PR DESCRIPTION
## Summary
- track background tasks by name for easier management
- stop watchers individually and report cancellation errors
- stub external modules in `tests/conftest.py`
- add integration test covering background task shutdown
- adapt existing tests to new `background_tasks` structure

## Testing
- `pytest tests/test_background_integration.py tests/test_functional_completeness.py::test_shutdown_cleans_tasks tests/test_startup_mode.py::test_startup_fast tests/test_shutdown.py -q`
- `pytest -q` *(fails: ModuleNotFoundError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6845f5df24488320b84e21f2bbab22b1