### PR TITLE
Implement async deep scan and symbolic training queue

### DIFF
--- a/devai/memory.py
+++ b/devai/memory.py
@@ -537,3 +537,13 @@ class MemoryManager:
         self.conn.commit()
         logger.info("Memorias antigas arquivadas", count=len(rows))
         return len(rows)
+
+    def close(self) -> None:
+        """Persist index and close database connection."""
+        try:
+            if self.index is not None:
+                self._persist_index()
+            self.conn.commit()
+            self.conn.close()
+        except Exception:
+            pass

--- a/tests/test_symbolic_training_queue.py
+++ b/tests/test_symbolic_training_queue.py
@@ -1,0 +1,38 @@
+import asyncio
+from devai.core import CodeMemoryAI
+
+class DummyAnalyzer:
+    pass
+
+class DummyMemory:
+    pass
+
+class DummyModel:
+    pass
+
+async def fake_run(*a, **k):
+    return {"report": "ok"}
+
+
+def test_queue_symbolic_training(monkeypatch):
+    sent = []
+    class DummyNotifier:
+        def send(self, subj, body):
+            sent.append(subj)
+    monkeypatch.setattr("devai.notifier.Notifier", DummyNotifier)
+    monkeypatch.setattr("devai.symbolic_training.run_symbolic_training", fake_run)
+
+    ai = object.__new__(CodeMemoryAI)
+    ai.analyzer = DummyAnalyzer()
+    ai.memory = DummyMemory()
+    ai.ai_model = DummyModel()
+    ai.background_tasks = {}
+
+    async def run():
+        queued = ai.queue_symbolic_training()
+        assert queued
+        task = ai.background_tasks["symbolic_training"]
+        await task
+
+    asyncio.run(run())
+    assert sent == ["Treinamento simb\u00f3lico conclu\u00eddo"]


### PR DESCRIPTION
## Summary
- add progress tracking to `deep_scan_app`
- expose progress and running tasks via `/status`
- run deep scans asynchronously and allow symbolic training to queue
- persist vector index on shutdown with new `MemoryManager.close`
- test queuing of symbolic training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fd5e83b883209e0f676d25457643