### PR TITLE
Implement log source tracking

### DIFF
--- a/devai/learning_engine.py
+++ b/devai/learning_engine.py
@@ -45,6 +45,7 @@ def registrar_licao_negativa(arquivo: str, erro: str) -> None:
             "erro": erro,
             "tipo": "licao_negativa",
             "timestamp": datetime.now().isoformat(),
+            "processed": False,
         }
     )
     LESSONS_FILE.write_text(json.dumps(data, indent=2))

--- a/devai/monitor_engine.py
+++ b/devai/monitor_engine.py
@@ -112,6 +112,10 @@ async def auto_monitor_cycle(
         if rules:
             plural = "s" if rules != 1 else ""
             lines.append(f"📌 {rules} nova{plural} regra{plural} aprendida.")
+            sources = result_data.get("rule_sources", {})
+            for idx, (rule, info) in enumerate(sources.items(), 1):
+                origin = info.get("files", ["?"])[0]
+                lines.append(f"🔗 Regra {idx} originada de {origin}")
         else:
             lines.append("🧠 Regras simbólicas atualizadas com base em novos erros.")
         logs_proc = result_data.get("errors_processed", 0)


### PR DESCRIPTION
## Summary
- record `processed` status in lessons database
- store origin logs/files when symbolic training creates new rules
- mark lessons as processed after training
- include rule origins in auto monitor messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ffbcd03883208e239f4baeed6e91