### PR TITLE
Enable multi-turn session history persistence

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -6,5 +6,5 @@ Este documento explica como executar e o que validar nos testes.
 - Os testes de integração simulam o ciclo IA → sugestão → teste → aplicação.
 - Rode-os sempre que alterar fluxos principais do DevAI.
 
-Alguns testes estão marcados com `@pytest.mark.skip` pois a memória multi-turno
-não está habilitada. Consulte `testing_fallbacks.md` para detalhes.
+Todos os testes são executados normalmente. O suporte a memória multi-turno está
+ativo, portanto não há casos marcados com `skip`.

--- a/devai/conversation_handler.py
+++ b/devai/conversation_handler.py
@@ -1,26 +1,58 @@
 from typing import Dict, List, Any
+import json
+from pathlib import Path
 
-from .config import logger
+from .config import logger, config
 from .dialog_summarizer import DialogSummarizer
 
 
 class ConversationHandler:
     """Gerencia o contexto de conversa multi-turno."""
 
-    def __init__(self, max_history: int = 10, summary_threshold: int = 20, memory: Any = None):
+    def __init__(
+        self,
+        max_history: int = 10,
+        summary_threshold: int = 20,
+        memory: Any = None,
+        history_dir: str | None = None,
+    ) -> None:
         self.conversation_context: Dict[str, List[Dict[str, str]]] = {}
         self.max_history = max_history
         self.summary_threshold = summary_threshold
         self.memory = memory
         self.summarizer = DialogSummarizer()
         self.symbolic_memories: List[str] = []
+        self.history_dir = Path(history_dir or Path(config.LOG_DIR) / "sessions")
+        self.history_dir.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def _estimate_tokens(text: str) -> int:
         return len(text.split())
 
+    def _history_file(self, session_id: str) -> Path:
+        return self.history_dir / f"{session_id}.json"
+
+    def _load_session(self, session_id: str) -> List[Dict[str, str]]:
+        file = self._history_file(session_id)
+        if file.exists():
+            try:
+                return json.loads(file.read_text())
+            except Exception:
+                return []
+        return []
+
+    def _save_session(self, session_id: str) -> None:
+        try:
+            self._history_file(session_id).write_text(
+                json.dumps(self.conversation_context.get(session_id, []), indent=2)
+            )
+        except Exception:
+            pass
+
     def history(self, session_id: str) -> List[Dict[str, str]]:
-        return self.conversation_context.setdefault(session_id, [])
+        if session_id not in self.conversation_context:
+            self.conversation_context[session_id] = self._load_session(session_id)
+        return self.conversation_context[session_id]
 
     def append(self, session_id: str, role: str, content: str) -> None:
         hist = self.history(session_id)
@@ -43,22 +75,29 @@ class ConversationHandler:
                     except Exception:
                         pass
             self.conversation_context[session_id] = hist[-self.max_history:]
+        self._save_session(session_id)
 
     def prune(self, session_id: str) -> None:
         """Mantém apenas as últimas mensagens definidas por max_history."""
         hist = self.history(session_id)
         if len(hist) > self.max_history:
             self.conversation_context[session_id] = hist[-self.max_history:]
+            self._save_session(session_id)
 
     def last(self, session_id: str, n: int) -> List[Dict[str, str]]:
         return self.history(session_id)[-n:]
 
     def reset(self, session_id: str) -> None:
         self.conversation_context[session_id] = []
+        self._save_session(session_id)
         logger.info("messages_cleared", session=session_id)
 
     def clear_session(self, session_id: str = "default") -> None:
         """Clear conversation history and temporary symbolic memories."""
         self.conversation_context[session_id] = []
+        try:
+            self._history_file(session_id).unlink()
+        except Exception:
+            pass
         self.symbolic_memories = []
         logger.info("session_reset", session=session_id)

--- a/testing_fallbacks.md
+++ b/testing_fallbacks.md
@@ -1,5 +1,4 @@
 # Fallbacks para testes
 
-- Testes que dependem de memória multi-turno ainda não estão ativos.
-- Por isso, `test_memory_multi_turn` fica marcado com `skip` até que a
-  funcionalidade seja implementada.
+Nenhum teste exige marcação especial atualmente. O suporte a memória multi-turno
+já está implementado e os testes relacionados rodam normalmente.

--- a/tests/test_conversation_persistence.py
+++ b/tests/test_conversation_persistence.py
@@ -1,0 +1,20 @@
+import os
+from devai.conversation_handler import ConversationHandler
+
+
+def test_history_persistence(tmp_path):
+    handler = ConversationHandler(history_dir=tmp_path)
+    handler.append("s", "user", "hi")
+    handler.append("s", "assistant", "hello")
+    new_handler = ConversationHandler(history_dir=tmp_path)
+    hist = new_handler.history("s")
+    assert len(hist) == 2
+    assert hist[0]["content"] == "hi"
+
+
+def test_history_cleanup(tmp_path):
+    handler = ConversationHandler(history_dir=tmp_path)
+    handler.append("x", "user", "a")
+    handler.clear_session("x")
+    new_handler = ConversationHandler(history_dir=tmp_path)
+    assert new_handler.history("x") == []


### PR DESCRIPTION
## Summary
- persist conversation history on disk per session
- load conversations when handler is recreated
- update docs removing skip notes
- add new tests ensuring recovery and cleanup

## Testing
- `pytest tests/test_memory_multi_turn.py tests/test_session_reset.py tests/test_conversation_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68460441a71483208ec79c141979b13f