### PR TITLE
Add session history sync and selective reset

### DIFF
--- a/tests/test_history_limit.py
+++ b/tests/test_history_limit.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+import types
+from devai.core import CodeMemoryAI
+from devai.conversation_handler import ConversationHandler
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None, temperature=0.0):
+        return "ok"
+
+
+def test_history_limit():
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
+    ai.analyzer = types.SimpleNamespace(graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now())
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.reason_stack = []
+    ai.double_check = False
+
+    for i in range(12):
+        ai.conv_handler.append("s", "user", f"q{i}")
+        ai.conv_handler.append("s", "assistant", f"a{i}")
+
+    history = ai._build_history_messages("s")
+    assert len(history) <= ai.conv_handler.max_history

--- a/tests/test_reset_conversation_endpoint.py
+++ b/tests/test_reset_conversation_endpoint.py
@@ -1,0 +1,43 @@
+import asyncio
+import types
+from datetime import datetime
+from devai.core import CodeMemoryAI
+from devai.conversation_handler import ConversationHandler
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None, temperature=0.0):
+        return "ok"
+
+
+def test_reset_conversation_endpoint(monkeypatch):
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
+    ai.analyzer = types.SimpleNamespace(graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now())
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.reason_stack = []
+    ai.double_check = False
+
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_get(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = app.post = fake_get
+    app.mount = lambda *a, **k: None
+    ai.app = app
+
+    CodeMemoryAI._setup_api_routes(ai)
+
+    ai.conv_handler.append("s", "user", "hi")
+    ai.conv_handler.symbolic_memories.append("pref")
+
+    fn = record['/reset_conversation']
+    result = asyncio.run(fn(session_id='s'))
+
+    assert result['status'] == 'reset'
+    assert ai.conv_handler.history('s') == []
+    assert ai.conv_handler.symbolic_memories == ['pref']


### PR DESCRIPTION
## Summary
- sync conversation files to support multi-turn persistence
- enforce history pruning when building prompts
- ignore missing `graph_summary_async` in tests
- add regression tests for history limit and reset endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68461038e4f88320ba47bd4958904b4f