### PR TITLE
Implement RLHF fine-tuning command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ python -m devai --cli
 Depois de registrar feedback positivo via API ou CLI, é possível refinar o modelo base utilizando a biblioteca [`trl`](https://github.com/huggingface/trl). Instale as dependências do projeto e execute:
 
 ```bash
-python -m devai.rlhf <modelo_base> ./model_ft
+python -m devai fine_tune <modelo_base> ./model_ft
 ```
 
 O comando coleta os exemplos do banco de memória, monta um pequeno dataset supervisionado e chama o `SFTTrainer` da `trl`. Os checkpoints do modelo e o arquivo `metrics.json` são gravados em `./model_ft`.
@@ -165,7 +165,7 @@ Melhorias em andamento:
 - Cache de memória para acelerar consultas
 - Sistema de plugins para novas tarefas *(implementado)*
 - Prompts com raciocínio em etapas *(Chain-of-Thought)*
-- Estrutura para treinamento via RLHF (execute `python -m devai.rlhf <modelo> <pasta>`)
+- Estrutura para treinamento via RLHF (execute `python -m devai fine_tune <modelo> <pasta>`)
 - Sandbox de execução para testes isolados *(planejado)*
 - Relatórios de cobertura integrados
 - Monitoramento de complexidade ao longo do tempo

--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -78,6 +78,12 @@ def main():
                 result = await run_symbolic_training(ai.analyzer, ai.memory, ai.ai_model)
                 print(json.dumps(result, indent=2))
                 return
+            elif cmd[0] == "fine_tune" and len(cmd) > 2:
+                from .rlhf import RLFineTuner
+                tuner = RLFineTuner(ai.memory)
+                result = await tuner.fine_tune(cmd[1], cmd[2])
+                print(json.dumps(result, indent=2))
+                return
             elif cmd[0] == "preferencia" and len(cmd) > 1:
                 from .feedback import registrar_preferencia
                 registrar_preferencia(" ".join(cmd[1:]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ aiofiles = "*"
 aiohttp = "*"
 structlog = "*"
 python-dotenv = "*"
+trl = "*"
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/tests/test_rlhf.py
+++ b/tests/test_rlhf.py
@@ -33,6 +33,15 @@ def test_collect_examples_returns_content(tmp_path):
     assert data and data[0]["prompt"] == "question"
 
 
+def test_collect_log_examples(tmp_path):
+    log = tmp_path / "run.log"
+    log.write_text("User: hi\nAssistant: hello\n")
+    mem = _create_memory(tmp_path)
+    tuner = rlhf.RLFineTuner(mem)
+    data = tuner._collect_from_logs(str(tmp_path))
+    assert {"prompt": "hi", "response": "hello", "score": 1} in data
+
+
 def test_fine_tune_creates_output(tmp_path):
     mem = _create_memory(tmp_path)
     tuner = rlhf.RLFineTuner(mem)


### PR DESCRIPTION
## Summary
- integrate RLHF trainer into CLI via `fine_tune` command
- parse logs for RLHF dataset creation
- document new command in README
- add TRL dependency to project metadata
- test log extraction for RLHF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684612e31cd88320ac411bdba87a15c3