### PR TITLE
Add rule origin tracking and async UI training

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -171,14 +171,18 @@ document.getElementById('investigate').onclick=async()=>{
   }
 };
 document.getElementById('trainSymbolic').onclick=async()=>{
-  appendConsole('Aprendendo com erros passados...');
+  appendConsole('Aprendizado simbólico iniciado...');
   const out=document.getElementById('aiOutput');
   showLoading();
-  out.textContent='🔄 Treinando...';
+  out.textContent='🔄 Treinamento em segundo plano...';
   try{
     const r=await fetch('/symbolic_training',{method:'POST'});
     const data=await r.json();
-    displayAIResponseFormatted(data);
+    if(data.status){
+      appendConsole('Treinamento agendado');
+    }else{
+      displayAIResponseFormatted(data);
+    }
     persistUI();
   }catch(e){
     out.textContent='Erro durante o treinamento simbólico.';

--- a/tests/test_symbolic_training.py
+++ b/tests/test_symbolic_training.py
@@ -9,29 +9,31 @@ from devai.config import config
 
 class DummyModel:
     async def generate(self, prompt, max_length=0):
-        if 'padroes ruins' in prompt:
-            return 'try/except generico'
-        if 'Como melhorar' in prompt:
-            return 'Padronizar estrutura'
-        return 'ok'
+        if "padroes ruins" in prompt:
+            return "try/except generico"
+        if "Como melhorar" in prompt:
+            return "Padronizar estrutura"
+        return "ok"
 
     async def safe_api_call(self, prompt, max_tokens, context="", memory=None):
         return await self.generate(prompt, max_length=max_tokens)
 
 
 def test_run_symbolic_training(tmp_path, monkeypatch):
-    code_root = tmp_path / 'app'
+    code_root = tmp_path / "app"
     code_root.mkdir()
-    monkeypatch.setattr('devai.learning_engine.LESSONS_FILE', tmp_path / 'lessons.json')
-    monkeypatch.setattr('devai.symbolic_training.LESSONS_FILE', tmp_path / 'lessons.json')
+    monkeypatch.setattr("devai.learning_engine.LESSONS_FILE", tmp_path / "lessons.json")
+    monkeypatch.setattr(
+        "devai.symbolic_training.LESSONS_FILE", tmp_path / "lessons.json"
+    )
     for i in range(3):
-        f = code_root / f'f{i}.py'
+        f = code_root / f"f{i}.py"
         f.write_text('print("hi")')
-        registrar_licao_negativa(str(f), f'erro{i}')
-    monkeypatch.setattr(config, 'CODE_ROOT', str(code_root))
-    log_dir = tmp_path / 'logs'
-    monkeypatch.setattr(config, 'LOG_DIR', str(log_dir))
-    mem = MemoryManager(str(tmp_path / 'mem.sqlite'), 'dummy', model=None, index=None)
+        registrar_licao_negativa(str(f), f"erro{i}")
+    monkeypatch.setattr(config, "CODE_ROOT", str(code_root))
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(config, "LOG_DIR", str(log_dir))
+    mem = MemoryManager(str(tmp_path / "mem.sqlite"), "dummy", model=None, index=None)
     analyzer = CodeAnalyzer(str(code_root), mem)
     model = DummyModel()
 
@@ -39,12 +41,14 @@ def test_run_symbolic_training(tmp_path, monkeypatch):
         return await run_symbolic_training(analyzer, mem, model)
 
     result = asyncio.run(run())
-    assert 'report' in result
-    assert '📌' in result['report'] or 'Nenhum aprendizado novo' in result['report']
-    assert 'Causa' in result['report']
-    data = result['data']
-    assert data['arquivos_com_erro'] == 3
-    assert data['errors_processed'] == 3
-    report = Path(log_dir / 'symbolic_training_report.md')
+    assert "report" in result
+    assert "📌" in result["report"] or "Nenhum aprendizado novo" in result["report"]
+    assert "Causa" in result["report"]
+    data = result["data"]
+    assert data["arquivos_com_erro"] == 3
+    assert data["errors_processed"] == 3
+    if data["new_rules"]:
+        first_rule = data["rules_added"][0]
+        assert data["rule_sources"][first_rule]["lines"]
+    report = Path(log_dir / "symbolic_training_report.md")
     assert report.exists()
-


### PR DESCRIPTION
## Summary
- record file and line for symbolic training rules
- show training as queued in the web UI
- test rule source metadata

## Testing
- `black devai/symbolic_training.py tests/test_symbolic_training.py`
- `pytest -q` *(fails: flake8, pylint, bandit and pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68461475054883209a860b8ed07e0439