### PR TITLE
Implement automatic dry run application with rollback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,8 +68,8 @@ Este arquivo lista sugestões de melhorias para o DevAI. Sinta-se livre para con
 - Executar treinamento simbólico de forma assíncrona
 - Autoavaliação com rastreamento simbólico por regra
 
-## Melhoria pendente – Aplicação de refatoração simulada
-- Permitir aplicar automaticamente o código sugerido pelo /dry_run preservando backup.
+## Melhoria implementada – Aplicação de refatoração simulada
+- Código do /dry_run pode ser aplicado automaticamente com backup e rollback.
 
 ## Melhoria pendente – Análise inteligente do test_output
 - Filtrar falhas individuais e exibir mensagens mais claras no resumo da simulação.

--- a/devai/update_manager.py
+++ b/devai/update_manager.py
@@ -45,6 +45,7 @@ class UpdateManager:
         apply_func: Callable[[Path], None],
         max_attempts: int = 1,
         capture_output: bool = False,
+        keep_backup: bool = False,
     ):
         """Apply modifications with automatic rollback if tests fail."""
         path = Path(file_path)
@@ -75,7 +76,8 @@ class UpdateManager:
                     success = self.run_tests()
                     out = ""
                 if success:
-                    backup.unlink(missing_ok=True)
+                    if not keep_backup:
+                        backup.unlink(missing_ok=True)
                     logger.info(
                         "Atualizacao aplicada com sucesso", file=str(path)
                     )
@@ -104,7 +106,8 @@ class UpdateManager:
 
                 success2, out2 = asyncio.run(_retry())
                 if success2:
-                    backup.unlink(missing_ok=True)
+                    if not keep_backup:
+                        backup.unlink(missing_ok=True)
                     logger.info(
                         "Atualizacao aplicada com sucesso", file=str(path)
                     )

--- a/static/index.html
+++ b/static/index.html
@@ -45,7 +45,7 @@
       <div class="dropdown-content">
         <button id="deep" title="Gera explicação com plano de raciocínio antes da resposta">🧠 Análise Profunda</button>
         <button id="shadowRefactor" title="Aplica uma mudança sugerida pela IA em modo simulado, sem afetar o código real" data-string="simulate_refactor">🕶️ Simular Refatoração</button>
-        <button id="applyRefactor" title="Aplica a mudança sugerida diretamente no código (usa backup interno)" data-string="apply_refactor">💾 Aplicar Refatoração</button>
+        <button id="applyRefactor" title="Aplica a mudança sugerida com backup e rollback automático" data-string="apply_refactor">💾 Aplicar Refatoração</button>
         <button id="trainSymbolic" title="Faz a IA aprender com erros passados e melhorar suas regras internas" data-string="train_from_errors">🧠 Aprendizado com Erros</button>
         <button id="autoMonitor" title="Executa um diagnóstico geral do sistema e aplica aprendizado automático, se necessário" data-string="auto_monitor">🧭 Monitoramento Automático</button>
       </div>

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -84,7 +84,14 @@ def test_auto_refactor(monkeypatch, tmp_path):
     class DummyUpdater:
         def __init__(self):
             self.called = False
-        def safe_apply(self, file_path, apply_func, max_attempts=1):
+        def safe_apply(
+            self,
+            file_path,
+            apply_func,
+            max_attempts=1,
+            capture_output=False,
+            keep_backup=False,
+        ):
             apply_func(Path(file_path))
             self.called = True
             return True

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -45,3 +45,18 @@ def test_safe_apply_failure(tmp_path, monkeypatch):
     assert file.read_text() == "old"
     # o backup eh movido de volta ao restaurar
     assert not file.with_suffix(".txt.bak").exists()
+
+
+def test_safe_apply_keep_backup(tmp_path, monkeypatch):
+    file = tmp_path / "f.py"
+    file.write_text("old")
+    mgr = UpdateManager()
+    monkeypatch.setattr(
+        mgr,
+        "run_tests",
+        lambda capture_output=False: (True, "") if capture_output else True,
+    )
+    result = mgr.safe_apply(file, lambda p: p.write_text("new"), keep_backup=True)
+    assert result
+    assert file.read_text() == "new"
+    assert file.with_suffix(".py.bak").exists()


### PR DESCRIPTION
## Summary
- enable optional backup retention in `UpdateManager.safe_apply`
- use `safe_apply` when applying dry-run results
- preserve backups and rollback on failure
- clarify roadmap item and update UI tooltip
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684617a071f88320a536e0e87afa46ed