### PR TITLE
Enhance auto-monitor rule reporting

### DIFF
--- a/devai/monitor_engine.py
+++ b/devai/monitor_engine.py
@@ -114,8 +114,12 @@ async def auto_monitor_cycle(
             lines.append(f"📌 {rules} nova{plural} regra{plural} aprendida.")
             sources = result_data.get("rule_sources", {})
             for idx, (rule, info) in enumerate(sources.items(), 1):
-                origin = info.get("files", ["?"])[0]
-                lines.append(f"🔗 Regra {idx} originada de {origin}")
+                arquivos = ", ".join(info.get("files", [])) or "?"
+                log_info = ", ".join(info.get("logs", []))
+                if log_info:
+                    lines.append(f"🔗 Regra {idx} em {arquivos} (logs: {log_info})")
+                else:
+                    lines.append(f"🔗 Regra {idx} em {arquivos}")
         else:
             lines.append("🧠 Regras simbólicas atualizadas com base em novos erros.")
         logs_proc = result_data.get("errors_processed", 0)

--- a/devai/symbolic_training.py
+++ b/devai/symbolic_training.py
@@ -144,6 +144,14 @@ async def run_symbolic_training(
     if sugg_lines:
         report.append("## Sugestões geradas")
         report.extend(sugg_lines)
+    if unique_rules:
+        report.append("")
+        report.append("## Origem das regras")
+        for idx, (rule, info) in enumerate(unique_rules.items(), 1):
+            files = ", ".join(sorted(info["files"]))
+            logs_ref = ", ".join(sorted(info["logs"]))
+            log_part = f" | Logs: {logs_ref}" if logs_ref else ""
+            report.append(f"- Regra {idx}: {files}{log_part}")
 
     Path(config.LOG_DIR).mkdir(exist_ok=True)
     Path(config.LOG_DIR, "symbolic_training_report.md").write_text("\n".join(report))
@@ -168,6 +176,10 @@ async def run_symbolic_training(
         )
         for i, (r, info) in enumerate(rules, 1):
             lines.append(f"📌 [{i}] {r}")
+            arquivos = ", ".join(sorted(info["files"]))
+            logs_ref = ", ".join(sorted(info["logs"]))
+            log_part = f" (logs: {logs_ref})" if logs_ref else ""
+            lines.append(f"🔗 Origem: {arquivos}{log_part}")
             rule_id = f"rule_{len(analyzer.learned_rules) + i}"
             analyzer.learned_rules[rule_id] = {
                 "rule": r,

--- a/tests/test_auto_monitor_response_format.py
+++ b/tests/test_auto_monitor_response_format.py
@@ -56,3 +56,43 @@ def test_auto_monitor_response_format(tmp_path, monkeypatch):
     result = asyncio.run(run())
     assert "🧭" in result["report"]
     assert result["data"]["training_executed"]
+
+
+def test_auto_monitor_rule_origins(tmp_path, monkeypatch):
+    code_root = tmp_path / "app"
+    code_root.mkdir()
+    f = code_root / "main.py"
+    f.write_text("print('x')")
+    _set_time(f, datetime.now())
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    training = log_dir / "symbolic_training_report.md"
+    training.write_text("old")
+    _set_time(training, datetime.now() - timedelta(hours=80))
+
+    monkeypatch.setattr(config, "CODE_ROOT", str(code_root))
+    monkeypatch.setattr(config, "LOG_DIR", str(log_dir))
+
+    mem = MemoryManager(str(tmp_path / "mem.sqlite"), "dummy", model=None, index=None)
+    analyzer = CodeAnalyzer(str(code_root), mem)
+    model = DummyModel()
+
+    mem.save({"type": "err", "memory_type": "erro_reincidente", "content": "x", "metadata": {}})
+
+    async def fake_run(*a, **k):
+        return {
+            "report": "",
+            "data": {
+                "new_rules": 1,
+                "errors_processed": 1,
+                "rule_sources": {"Use padrões": {"files": [str(f)], "logs": ["x"]}},
+            },
+        }
+
+    monkeypatch.setattr("devai.monitor_engine.run_symbolic_training", fake_run)
+
+    async def run():
+        return await auto_monitor_cycle(analyzer, mem, model)
+
+    result = asyncio.run(run())
+    assert "logs:" in result["report"]


### PR DESCRIPTION
## Summary
- show detailed file and log origins for rules in auto-monitor
- record origin details in symbolic training report
- extend monitor summary to display rule origins
- test rule origin output

## Testing
- `pytest`
- `flake8` *(fails: command not found)*
- `bandit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461d5418288320b77fe4a9399044a8