### PR TITLE
Implement error log persistence

### DIFF
--- a/devai/core.py
+++ b/devai/core.py
@@ -21,6 +21,7 @@ from .api_schemas import (
 from fastapi.staticfiles import StaticFiles
 
 from .config import config, logger, metrics, api_key_missing
+from .error_handler import load_persisted_errors, persist_errors
 from .complexity_tracker import ComplexityTracker
 from .memory import MemoryManager
 from .analyzer import CodeAnalyzer
@@ -1060,4 +1061,5 @@ class CodeMemoryAI:
                     self.watchers.pop(name, None)
         if hasattr(self, "memory") and hasattr(self.memory, "close"):
             self.memory.close()
+        await persist_errors()
         logger.info("🛑 DevAI finalizado com limpeza simbólica de recursos.")

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -5,6 +5,8 @@ from devai.error_handler import (
     friendly_message,
     log_error,
     error_memory,
+    persist_errors,
+    load_persisted_errors,
 )
 
 
@@ -51,3 +53,15 @@ def test_log_error_records():
 def test_friendly_unknown():
     msg = friendly_message(RuntimeError("x"))
     assert "Algo deu errado" in msg
+
+
+def test_persist_and_load_errors(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    error_memory.clear()
+    log_error("unit_test", ValueError("boom"))
+    asyncio.run(persist_errors())
+    assert (tmp_path / "errors_log.jsonl").exists()
+    error_memory.clear()
+    load_persisted_errors()
+    assert error_memory
+    assert error_memory[-1]["função"] == "unit_test"


### PR DESCRIPTION
## Summary
- persist error logs to disk and reload them at startup
- store error log on shutdown
- test persistence logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462161c94c8320975a2a7b7e91e669