### PR TITLE
Improve dynamic prompt filtering

### DIFF
--- a/tests/test_dynamic_prompt.py
+++ b/tests/test_dynamic_prompt.py
@@ -22,3 +22,15 @@ def test_dynamic_prompt_fallback_logged(caplog):
         build_dynamic_prompt("Oi", context, "normal")
     assert any("Fallback" in r.message for r in caplog.records)
 
+
+def test_dynamic_prompt_logs_reasons(caplog):
+    context = {
+        "logs": "trace",
+        "actions": [{"task": "run"}],
+        "graph": "g",
+        "memories": [],
+    }
+    with caplog.at_level(logging.INFO):
+        build_dynamic_prompt("Por que deu erro?", context, "normal", intent="debug")
+    assert any("reasons=" in r.message for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- filter context blocks adaptively in `build_dynamic_prompt`
- log included blocks with reasons for audit
- only add "Explique antes de responder." for certain intents
- add regression test for logging of reasons

## Testing
- `pytest -q`
- `pytest > /tmp/pytest.log && tail -n 3 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68462311f75483209d57b156bca1e1fe