### PR TITLE
Add session history sync

### DIFF
--- a/devai/core.py
+++ b/devai/core.py
@@ -249,10 +249,15 @@ class CodeMemoryAI:
             return {"status": "reset", "session": session_id}
 
         @self.app.post("/session/reset")
-        async def reset_session():
-            self.conv_handler.clear_session()
-            self.conversation = self.conv_handler.history("default")
-            return {"status": "ok", "message": "Sessão reiniciada com sucesso"}
+        async def reset_session(session_id: str = "default"):
+            self.conv_handler.clear_session(session_id)
+            if session_id == "default":
+                self.conversation = self.conv_handler.history("default")
+            return {"status": "ok", "session": session_id}
+
+        @self.app.get("/session/history")
+        async def session_history(session_id: str = "default"):
+            return self.conv_handler.history(session_id)
 
         @self.app.post("/analyze_deep")
         async def analyze_deep(query: str, session_id: str = "default"):

--- a/static/script.js
+++ b/static/script.js
@@ -185,7 +185,7 @@ function showHistoryWarning(){
 
 async function syncChatFromBackend(){
   try{
-    const r=await fetch('/history');
+    const r=await fetch('/session/history');
     const hist=await r.json();
     if(Array.isArray(hist)){
       window.chatHistory=hist;
@@ -228,7 +228,7 @@ function addSystemMessage(msg){
 }
 
 async function resetSession(){
-  await fetch('/session/reset', {method:'POST'});
+  await fetch('/session/reset?session_id=default', {method:'POST'});
   clearUIConversation();
   try{localStorage.removeItem(CHAT_KEY);}catch(e){}
   addSystemMessage('✅ Sessão reiniciada com sucesso.');
@@ -254,7 +254,7 @@ window.addEventListener('load',async()=>{
     if('show_reasoning_default' in info) showReasoningByDefault=info.show_reasoning_default;
     if('show_context_button' in info) showContextButton=info.show_context_button;
   }catch(e){}
-  // syncChatFromBackend(); // habilitar quando endpoint /history estiver disponível
+  syncChatFromBackend();
   const btn=document.getElementById('clearHistoryBtn');
   if(btn) btn.onclick=clearChat;
   const reset=document.getElementById('reset-session-btn');

--- a/tests/test_session_history_endpoint.py
+++ b/tests/test_session_history_endpoint.py
@@ -1,0 +1,54 @@
+import asyncio
+import types
+from datetime import datetime
+
+from devai.core import CodeMemoryAI
+from devai.conversation_handler import ConversationHandler
+
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None, temperature=0.0):
+        return "ok"
+
+
+def _setup_ai():
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
+    ai.analyzer = types.SimpleNamespace(graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now())
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.reason_stack = []
+    ai.double_check = False
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_get(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = app.post = fake_get
+    app.mount = lambda *a, **k: None
+    ai.app = app
+    CodeMemoryAI._setup_api_routes(ai)
+    return ai, record
+
+
+def test_session_history_endpoint():
+    ai, record = _setup_ai()
+    ai.conv_handler.append("s", "user", "hi")
+    ai.conv_handler.append("s", "assistant", "hello")
+    fn = record["/session/history"]
+    hist = asyncio.run(fn(session_id="s"))
+    assert len(hist) == 2
+    assert hist[0]["role"] == "user"
+
+
+def test_session_reset_isolated():
+    ai, record = _setup_ai()
+    ai.conv_handler.append("a", "user", "1")
+    ai.conv_handler.append("b", "user", "2")
+    reset_fn = record["/session/reset"]
+    asyncio.run(reset_fn(session_id="a"))
+    assert ai.conv_handler.history("a") == []
+    assert ai.conv_handler.history("b")


### PR DESCRIPTION
## Summary
- provide `/session/history` endpoint and make `/session/reset` accept session id
- automatically sync chat history with the backend and use new reset URL
- add regression test for new endpoints

## Testing
- `flake8 devai`
- `bandit -r devai`
- `mypy devai`
- `pylint -E devai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462635f21883209e016d8a7fa76b25