### PR TITLE
Improve response split and plan display

### DIFF
--- a/devai/core.py
+++ b/devai/core.py
@@ -783,7 +783,7 @@ class CodeMemoryAI:
 
         Accept minor variations like spaces around the marker.
         """
-        m = re.search(r"===\s*RESPOSTA\s*===", text)
+        m = re.search(r"===\s*RESPOSTA\s*===", text, re.IGNORECASE)
         if m:
             plan = text[: m.start()]
             resp = text[m.end() :]

--- a/static/index.html
+++ b/static/index.html
@@ -55,6 +55,7 @@
   <div id="aiPanel">
     <h3>Painel IA</h3>
     <div id="ia-panel" class="chat"></div>
+    <pre id="planOutput"></pre>
     <pre id="aiOutput"></pre>
     <button id="toggleReason" style="display:none;" onclick="toggleReasoning()">👁️ Ver raciocínio da IA</button>
     <button id="showContextBtn" style="display:none;" onclick="toggleContext()">🧠 Contexto Atual</button>
@@ -127,7 +128,9 @@ async function send(cot){
     const r=await fetch(url+'?'+new URLSearchParams({query:q}),{method:'POST'});
     let data;
     try{ data=await r.json(); }catch(e){ data={}; }
-    if(data.plan) appendConsole('🧠 Plano de Raciocínio:\n'+data.plan);
+    if(data.plan){
+      document.getElementById('planOutput').textContent=data.plan;
+    }
     const answer=data.main_response||data.response||'';
     document.getElementById('aiOutput').textContent=answer;
     addChat('assistant',answer);

--- a/static/script.js
+++ b/static/script.js
@@ -207,6 +207,7 @@ function persistUI(){
   const consoleLines=document.getElementById('console').textContent.split('\n').slice(-20).join('\n');
   saveSession({
     console:consoleLines,
+    planOutput:document.getElementById('planOutput')?document.getElementById('planOutput').innerHTML:'',
     aiOutput:document.getElementById('aiOutput').innerHTML,
     reasoning:document.getElementById('reasoningOutput').innerHTML,
     diffOutput:document.getElementById('diffOutput').innerHTML,
@@ -218,6 +219,8 @@ function clearUIConversation(){
   localStorage.removeItem(SESSION_KEY);
   clearChat();
   document.getElementById('console').textContent='';
+  const plan=document.getElementById('planOutput');
+  if(plan) plan.innerHTML='';
   document.getElementById('aiOutput').innerHTML='';
   document.getElementById('reasoningOutput').innerHTML='';
   document.getElementById('diffOutput').innerHTML='';
@@ -240,6 +243,7 @@ window.addEventListener('load',async()=>{
   const data=loadSession();
   if(data){
     document.getElementById('console').textContent=data.console||'';
+    if('planOutput' in data) document.getElementById('planOutput').innerHTML=data.planOutput||'';
     document.getElementById('aiOutput').innerHTML=data.aiOutput||'';
     document.getElementById('reasoningOutput').innerHTML=data.reasoning||'';
     document.getElementById('diffOutput').innerHTML=data.diffOutput||'';


### PR DESCRIPTION
## Summary
- relax _split_plan_response regex
- show plan separately in the web panel
- persist plan data in session storage
- verify deep analysis parsing even if max_tokens ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684636234cfc8320b527d1a8db7841c4