### PR TITLE
Track rule origins in learning pipeline

### DIFF
--- a/devai/monitor_engine.py
+++ b/devai/monitor_engine.py
@@ -83,6 +83,7 @@ async def auto_monitor_cycle(
         "training_executed": False,
         "new_rules": 0,
         "errors_processed": 0,
+        "rule_sources": {},
     }
 
     _log("🧠 Avaliando necessidade de novo treinamento simbólico…")
@@ -90,7 +91,12 @@ async def auto_monitor_cycle(
         training_executed = True
         _log("EXECUTADO")
         logger.info("Monitor acionou treinamento simbólico")
-        training_result = await run_symbolic_training(analyzer, memory, ai_model)
+        from .learning_engine import LearningEngine
+
+        engine = LearningEngine(analyzer, memory, ai_model)
+        training_result = await run_symbolic_training(
+            analyzer, memory, ai_model, learning_engine=engine
+        )
         result_data.update(training_result.get("data", {}))
         result_data["training_executed"] = True
         decision_log.write_text(

--- a/tests/test_auto_monitor_response_format.py
+++ b/tests/test_auto_monitor_response_format.py
@@ -96,3 +96,4 @@ def test_auto_monitor_rule_origins(tmp_path, monkeypatch):
 
     result = asyncio.run(run())
     assert "logs:" in result["report"]
+    assert result["data"]["rule_sources"]["Use padrões"]["files"]


### PR DESCRIPTION
## Summary
- keep origin metadata for learned rules via `LearningEngine.register_rule`
- skip already processed logs when learning from errors
- record processing time in `symbolic_training`
- always include rule origin data in monitor output
- check rule origin details in auto-monitor tests

## Testing
- `flake8 devai` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463aa230f4832089fe7ffc035b03bc