### PR TITLE
Add RLHF CLI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ python -m devai --cli
 Depois de registrar feedback positivo via API ou CLI, é possível refinar o modelo base utilizando a biblioteca [`trl`](https://github.com/huggingface/trl). Instale as dependências do projeto e execute:
 
 ```bash
-python -m devai fine_tune <modelo_base> ./model_ft
+python -m devai.rlhf <modelo_base> ./model_ft
 ```
 
 O comando coleta os exemplos do banco de memória, monta um pequeno dataset supervisionado e chama o `SFTTrainer` da `trl`. Os checkpoints do modelo e o arquivo `metrics.json` são gravados em `./model_ft`.
@@ -165,7 +165,7 @@ Melhorias em andamento:
 - Cache de memória para acelerar consultas
 - Sistema de plugins para novas tarefas *(implementado)*
 - Prompts com raciocínio em etapas *(Chain-of-Thought)*
-- Estrutura para treinamento via RLHF (execute `python -m devai fine_tune <modelo> <pasta>`)
+- Estrutura para treinamento via RLHF (execute `python -m devai.rlhf <modelo> <pasta>`)
 - Sandbox de execução para testes isolados *(implementado)*
 - Relatórios de cobertura integrados
 - Monitoramento de complexidade ao longo do tempo

--- a/devai/rlhf.py
+++ b/devai/rlhf.py
@@ -120,18 +120,24 @@ class RLFineTuner:
         return metrics
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> None:
+    """CLI entrypoint for running the fine-tuning procedure."""
     import argparse
     import asyncio
+
     from .memory import MemoryManager
-    from .config import config
 
     parser = argparse.ArgumentParser(description="Run RLHF fine-tuning")
     parser.add_argument("base_model")
     parser.add_argument("output_dir")
     parser.add_argument("--db", default=config.MEMORY_DB)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     mem = MemoryManager(args.db, config.EMBEDDING_MODEL, model=None, index=None)
     tuner = RLFineTuner(mem)
-    asyncio.run(tuner.fine_tune(args.base_model, args.output_dir))
+    result = asyncio.run(tuner.fine_tune(args.base_model, args.output_dir))
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ psutil
 PyYAML
 PyJWT
 python-dotenv
-trl
+trl>=0.7

--- a/tests/test_rlhf.py
+++ b/tests/test_rlhf.py
@@ -8,7 +8,7 @@ from devai.memory import MemoryManager
 
 
 class DummyMemory(MemoryManager):
-    def __init__(self, path: str):
+    def __init__(self, path: str, *a, **k):
         super().__init__(path, "dummy", model=None, index=None)
 
 
@@ -49,3 +49,15 @@ def test_fine_tune_creates_output(tmp_path):
     result = asyncio.run(tuner.fine_tune("base", str(out)))
     assert out.exists()
     assert "status" in result
+
+
+def test_cli_main_runs(tmp_path, monkeypatch, capsys):
+    _create_memory(tmp_path)
+    out = tmp_path / "model"
+    import devai.memory as memory_module
+    monkeypatch.setattr(memory_module, "MemoryManager", DummyMemory)
+    monkeypatch.setattr(rlhf.config, "MEMORY_DB", str(tmp_path / "mem.sqlite"))
+    rlhf.main(["base", str(out)])
+    out_text = capsys.readouterr().out
+    assert out.exists()
+    assert "status" in out_text


### PR DESCRIPTION
## Summary
- install `trl`
- add CLI entrypoint in `devai.rlhf` with graceful fallbacks
- document usage in README
- test RLHF CLI helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68463f1362788320b1b45bcfdc57920c