### PR TITLE
Persist FAISS index across restarts

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,6 @@
 import tempfile
 import json
+from typing import Any
 from pathlib import Path
 from devai.memory import MemoryManager
 from devai.config import config
@@ -119,3 +120,44 @@ def test_compress_and_prune_memory(tmp_path, monkeypatch):
     assert pruned == 1
     latent = Path(str(tmp_path)) / "latent_memory.json"
     assert latent.exists()
+
+
+def test_index_persistence(tmp_path, monkeypatch):
+    import devai.memory as memory_module
+
+    class FakeFaiss:
+        store: dict[str, Any] = {}
+
+        class IndexFlatL2:
+            def __init__(self, dim):
+                self.dim = dim
+                self.vectors: list[list[float]] = []
+
+            def add(self, embeddings):
+                self.vectors.extend(list(embeddings))
+
+            def search(self, query, k):  # pragma: no cover - not used
+                return [[0.0]], [[0]]
+
+        @staticmethod
+        def write_index(index, path):
+            FakeFaiss.store[path] = index
+            Path(path).write_bytes(b"dummy")
+
+        @staticmethod
+        def read_index(path):
+            return FakeFaiss.store.get(path)
+
+    monkeypatch.setattr(memory_module, "faiss", FakeFaiss)
+    monkeypatch.setattr(memory_module, "np", None)
+    monkeypatch.setattr(config, "INDEX_FILE", str(tmp_path / "idx.bin"))
+    monkeypatch.setattr(config, "INDEX_IDS_FILE", str(tmp_path / "ids.json"))
+
+    db = str(tmp_path / "mem.sqlite")
+    model = DummyModel()
+    mem1 = MemoryManager(db, "dummy", model=model, index=None)
+    mem1.save({"type": "note", "content": "hello", "metadata": {}, "tags": []})
+    mem1.persist_index()
+
+    mem2 = MemoryManager(db, "dummy", model=model, index=None)
+    assert mem2.indexed_ids == mem1.indexed_ids


### PR DESCRIPTION
## Summary
- make MemoryManager load index from files on init
- allow persisting/loading index via public methods
- persist the index whenever saving, rebuilding or closing
- test index persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846435972588320885fc4b93358e1eb