### PR TITLE
Implement async summarization and token limits

### DIFF
--- a/devai/config.py
+++ b/devai/config.py
@@ -42,6 +42,7 @@ class Config:
     INDEX_IDS_FILE: str = "faiss_ids.json"
     NOTIFY_EMAIL: str = os.getenv("NOTIFY_EMAIL", "")
     LOCAL_MODEL: str = os.getenv("LOCAL_MODEL", "")
+    MAX_SESSION_TOKENS: int = 1000
     COMPLEXITY_HISTORY: str = "complexity_history.json"
     LOG_AGGREGATOR_URL: str = os.getenv("LOG_AGGREGATOR_URL", "")
     DOUBLE_CHECK: bool = False

--- a/devai/conversation_handler.py
+++ b/devai/conversation_handler.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Any
 import json
 from pathlib import Path
+import asyncio
 
 from .config import logger, config
 from .dialog_summarizer import DialogSummarizer
@@ -44,6 +45,19 @@ class ConversationHandler:
                 return []
         return []
 
+    def _trim_by_tokens(self, session_id: str, max_tokens: int) -> None:
+        """Remove oldest messages until total tokens fits within limit."""
+        hist = self.history(session_id)
+        total = sum(self._estimate_tokens(m.get("content", "")) for m in hist)
+        changed = False
+        while hist and total > max_tokens:
+            msg = hist.pop(0)
+            total -= self._estimate_tokens(msg.get("content", ""))
+            changed = True
+        if changed:
+            self.conversation_context[session_id] = hist
+            self._save_session(session_id)
+
     def _save_session(self, session_id: str) -> None:
         try:
             file = self._history_file(session_id)
@@ -67,11 +81,9 @@ class ConversationHandler:
             self.conversation_context.setdefault(session_id, [])
         return self.conversation_context[session_id]
 
-    def append(self, session_id: str, role: str, content: str) -> None:
-        hist = self.history(session_id)
-        hist.append({"role": role, "content": content})
-        self.prune(session_id)
-        if len(hist) >= self.summary_threshold:
+    async def _summarize_and_store(self, session_id: str, hist: List[Dict[str, str]]) -> None:
+        """Summarize history and persist symbolic memories."""
+        try:
             summary = self.summarizer.summarize_conversation(hist)
             if summary and self.memory:
                 for item in summary:
@@ -88,7 +100,24 @@ class ConversationHandler:
                     except Exception:
                         pass
             self.conversation_context[session_id] = hist[-self.max_history:]
-        self._save_session(session_id)
+            self._save_session(session_id)
+        except Exception:
+            pass
+
+    def append(self, session_id: str, role: str, content: str) -> None:
+        hist = self.history(session_id)
+        hist.append({"role": role, "content": content})
+        self.prune(session_id)
+        self._trim_by_tokens(session_id, config.MAX_SESSION_TOKENS)
+        if len(hist) >= self.summary_threshold:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(self._summarize_and_store(session_id, hist.copy()))
+            else:
+                asyncio.create_task(self._summarize_and_store(session_id, hist.copy()))
+        else:
+            self._save_session(session_id)
 
     def prune(self, session_id: str) -> None:
         """Mantém apenas as últimas mensagens definidas por max_history."""

--- a/tests/test_memory_multi_turn.py
+++ b/tests/test_memory_multi_turn.py
@@ -1,4 +1,6 @@
+import asyncio
 from devai.conversation_handler import ConversationHandler
+from devai.config import config
 
 
 class DummyMemory:
@@ -9,10 +11,17 @@ class DummyMemory:
         self.saved.append(item)
 
 
-def test_memory_multi_turn():
+def test_memory_multi_turn(monkeypatch):
     mem = DummyMemory()
     handler = ConversationHandler(max_history=5, summary_threshold=2, memory=mem)
-    handler.append("s", "user", "Prefiro usar funcoes puras")
-    handler.append("s", "assistant", "Ok")
-    assert mem.saved
+    monkeypatch.setattr(config, "MAX_SESSION_TOKENS", 100)
+
+    async def run():
+        handler.append("s", "user", "Prefiro usar funcoes puras")
+        handler.append("s", "assistant", "Ok")
+        assert mem.saved == []
+        await asyncio.sleep(0.01)
+        assert mem.saved
+
+    asyncio.run(run())
     assert mem.saved[0]["memory_type"] == "dialog_summary"

--- a/tests/test_token_trim.py
+++ b/tests/test_token_trim.py
@@ -1,0 +1,18 @@
+import asyncio
+from devai.conversation_handler import ConversationHandler
+from devai.config import config
+
+class DummyMemory:
+    def save(self, item):
+        pass
+
+def test_token_trim(monkeypatch):
+    handler = ConversationHandler()
+    monkeypatch.setattr(config, "MAX_SESSION_TOKENS", 7)
+    handler.append("s", "user", "a b c d e")
+    handler.append("s", "assistant", "f g")
+    handler.append("s", "user", "h i j k l")
+    hist = handler.history("s")
+    total = sum(handler._estimate_tokens(m["content"]) for m in hist)
+    assert total <= 7
+    assert hist[0]["content"] == "f g"


### PR DESCRIPTION
## Summary
- make conversation summarization run in background tasks
- add token-based trimming of session history
- expose `MAX_SESSION_TOKENS` in config
- adjust existing test for async summarization
- test token trimming behaviour

## Testing
- `pytest -q -vv`

------
https://chatgpt.com/codex/tasks/task_e_68465579cb4c8320bec20e0709a18611