### PR TITLE
Add RLHF training helper and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,16 @@ python -m devai --cli
 
 ## Treinamento RLHF
 
-Depois de registrar feedback positivo via API ou CLI, é possível refinar o modelo base utilizando a biblioteca [`trl`](https://github.com/huggingface/trl). Instale as dependências do projeto e execute:
+Depois de registrar feedback positivo via API ou CLI, é possível refinar o modelo base utilizando a biblioteca [`trl`](https://github.com/huggingface/trl).
+Instale as dependências opcionais `transformers` e `trl` e execute:
 
 ```bash
 python -m devai.rlhf <modelo_base> ./model_ft
+# ou pela CLI interativa
+/treinar_rlhf <modelo_base> [pasta_destino]
 ```
 
-O comando coleta os exemplos do banco de memória, monta um pequeno dataset supervisionado e chama o `SFTTrainer` da `trl`. Os checkpoints do modelo e o arquivo `metrics.json` são gravados em `./model_ft`.
+O comando coleta os exemplos do banco de memória, monta um pequeno dataset supervisionado e chama o `SFTTrainer` da `trl`. Os checkpoints do modelo e o arquivo `metrics.json` são gravados no diretório indicado.
 
 ### Integração contínua
 
@@ -165,7 +168,7 @@ Melhorias em andamento:
 - Cache de memória para acelerar consultas
 - Sistema de plugins para novas tarefas *(implementado)*
 - Prompts com raciocínio em etapas *(Chain-of-Thought)*
-- Estrutura para treinamento via RLHF (execute `python -m devai.rlhf <modelo> <pasta>`)
+- Estrutura para treinamento via RLHF (execute `python -m devai.rlhf <modelo> <pasta>` ou use `/treinar_rlhf` pela CLI)
 - Sandbox de execução para testes isolados *(implementado)*
 - Relatórios de cobertura integrados
 - Monitoramento de complexidade ao longo do tempo

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -231,6 +231,16 @@ async def cli_main(guided: bool = False):
                     hist = await ai.analyzer.get_history(file)
                     for h in hist:
                         print(json.dumps(h, indent=2))
+                elif user_input.startswith("/treinar_rlhf"):
+                    parts = user_input.split()
+                    if len(parts) < 2:
+                        print("Uso: /treinar_rlhf <modelo_base> [destino]")
+                    else:
+                        base = parts[1]
+                        out = parts[2] if len(parts) > 2 else "./model_ft"
+                        from .rlhf import train_from_memory
+                        result = await train_from_memory(base, out)
+                        print(json.dumps(result, indent=2))
                 elif user_input.startswith("/feedback "):
                     parts = user_input[len("/feedback "):].split(maxsplit=2)
                     if len(parts) < 3:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,11 @@ numpy
 scikit-learn>=1.3
 sentence-transformers
 faiss-cpu
+# Optional: treinamento RLHF
 transformers
 psutil
 PyYAML
 PyJWT
 python-dotenv
+# Optional: treinamento RLHF
 trl>=0.7

--- a/tests/test_rlhf.py
+++ b/tests/test_rlhf.py
@@ -61,3 +61,12 @@ def test_cli_main_runs(tmp_path, monkeypatch, capsys):
     out_text = capsys.readouterr().out
     assert out.exists()
     assert "status" in out_text
+
+
+def test_train_from_memory_empty(tmp_path, monkeypatch):
+    import devai.memory as memory_module
+    monkeypatch.setattr(memory_module, "MemoryManager", DummyMemory)
+    monkeypatch.setattr(rlhf.config, "MEMORY_DB", str(tmp_path / "mem.sqlite"))
+
+    result = asyncio.run(rlhf.train_from_memory("base", str(tmp_path / "out")))
+    assert result["status"] == "no_data"


### PR DESCRIPTION
## Summary
- mark transformers and trl as optional deps
- warn when RLHF libs are missing and add `train_from_memory`
- expose new `/treinar_rlhf` command via CLI
- document RLHF usage in README
- test training helper when no data is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846581fa0088320898742a300bfb83e