### PR TITLE
Add conversation history search and embeddings

### DIFF
--- a/devai/memory.py
+++ b/devai/memory.py
@@ -131,6 +131,16 @@ class MemoryManager:
             )
             """
         )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS conversation_embeddings (
+                session_id TEXT,
+                message_id INTEGER,
+                vector BLOB,
+                PRIMARY KEY (session_id, message_id)
+            )
+            """
+        )
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_memory_feedback ON memory(feedback_score)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_memory_access ON memory(access_count)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_memory_type ON memory(memory_type)")

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,3 +28,9 @@ TEST_MEMORY_LIMIT_MB: 512  # memória máxima em MB
 
 Quando `TESTS_USE_ISOLATION` for `true`, o DevAI executará `pytest` em um container Docker com os limites configurados.
 
+## Histórico de conversa
+
+O parâmetro `MAX_SESSION_TOKENS` controla a quantidade máxima de tokens mantidos no arquivo de histórico de cada sessão. Ao exceder esse limite, as mensagens mais antigas são removidas (pruning). Defina `0` para desabilitar a limpeza automática.
+
+A classe `ConversationHandler` oferece o método `search_history(session_id, query)` que utiliza embeddings gravados em `memory.db` para localizar mensagens similares ao texto ou tag informados.
+

--- a/tests/test_conversation_search.py
+++ b/tests/test_conversation_search.py
@@ -1,0 +1,36 @@
+import types
+from devai.memory import MemoryManager
+from devai.conversation_handler import ConversationHandler
+import devai.conversation_handler as conv_module
+
+class FakeFaiss:
+    class IndexFlatL2:
+        def __init__(self, dim):
+            self.vectors = []
+        def add(self, embeddings):
+            self.vectors.extend(list(embeddings))
+        def search(self, query, k):
+            val = query[0][0] if isinstance(query[0], (list, tuple)) else query[0]
+            dists = [abs(v[0] - val) for v in self.vectors]
+            idx = sorted(range(len(dists)), key=lambda i: dists[i])[:k]
+            return [[dists[i] for i in idx]], [idx]
+
+class DummyModel:
+    def __init__(self):
+        self.dim = 1
+    def get_sentence_embedding_dimension(self):
+        return self.dim
+    def encode(self, text):
+        return [0.0 if "hello" in text else 1.0]
+
+def test_search_history(monkeypatch, tmp_path):
+    monkeypatch.setattr(conv_module, "faiss", FakeFaiss)
+    db = str(tmp_path / "mem.sqlite")
+    model = DummyModel()
+    mem = MemoryManager(db, "dummy", model=model, index=None)
+    handler = ConversationHandler(memory=mem, history_dir=tmp_path)
+    handler.append("s", "user", "hello there")
+    handler.append("s", "assistant", "bye now")
+    results = handler.search_history("s", "hello")
+    assert results
+    assert results[0]["content"] == "hello there"


### PR DESCRIPTION
## Summary
- store conversation embeddings in SQLite
- generate conversation embeddings when adding messages
- allow searching conversation history using FAISS
- document history pruning and search method
- add unit test for conversation search

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68465e7ea5ac8320b0b223fc1bd072cb