### PR TITLE
Enhance log monitoring with persistent offsets

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,7 @@
 CODE_ROOT: ./app
 API_PORT: 8000
 LOG_DIR: ./logs
+LOG_MONITOR_INTERVAL: 60
 MODELS:
   default:
     name: deepseek/deepseek-r1-0528:free

--- a/devai/config.py
+++ b/devai/config.py
@@ -31,6 +31,7 @@ class Config:
     EMBEDDING_MODEL: str = "all-MiniLM-L6-v2"
     TASK_DEFINITIONS: str = "tasks.yaml"
     LOG_DIR: str = "./logs"
+    LOG_MONITOR_INTERVAL: int = 60
     FILE_HISTORY: str = "file_history.json"
     API_SECRET: str = os.getenv("API_SECRET", "")
     API_PORT: int = 8000
@@ -86,6 +87,8 @@ class Config:
             raise ValueError("API_PORT must be integer")
         if not isinstance(self.LEARNING_LOOP_INTERVAL, int):
             raise ValueError("LEARNING_LOOP_INTERVAL must be integer")
+        if not isinstance(self.LOG_MONITOR_INTERVAL, int):
+            raise ValueError("LOG_MONITOR_INTERVAL must be integer")
         if self.START_MODE not in {"fast", "full", "custom"}:
             raise ValueError("START_MODE must be 'fast', 'full' or 'custom'")
         if not isinstance(self.START_TASKS, list):

--- a/devai/core.py
+++ b/devai/core.py
@@ -356,6 +356,10 @@ class CodeMemoryAI:
         async def get_metrics():
             return metrics.summary()
 
+        @self.app.get("/logs/recent")
+        async def recent_logs(limit: int = 20):
+            return self.memory.recent_entries("log_analysis", limit)
+
         @self.app.get("/admin")
         async def admin_panel():
             return {

--- a/devai/memory.py
+++ b/devai/memory.py
@@ -549,6 +549,26 @@ class MemoryManager:
         logger.info("Memoria comprimida", count=len(duplicates))
         return len(duplicates)
 
+    def recent_entries(self, entry_type: str, limit: int = 10) -> List[Dict]:
+        """Return the most recent memory entries of a given type."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT id, type, content, metadata, created_at FROM memory "
+            "WHERE type = ? ORDER BY id DESC LIMIT ?",
+            (entry_type, limit),
+        )
+        rows = cursor.fetchall()
+        return [
+            {
+                "id": r[0],
+                "type": r[1],
+                "content": r[2],
+                "metadata": json.loads(r[3]),
+                "created_at": r[4],
+            }
+            for r in rows
+        ]
+
     def prune_old_memories(self, threshold_days: int = 30) -> int:
         """Archive old memories to latent_memory.json with a symbolic reference."""
         cutoff = datetime.now() - timedelta(days=threshold_days)


### PR DESCRIPTION
## Summary
- track file positions in log monitor
- add configurable interval `LOG_MONITOR_INTERVAL`
- persist monitor offsets and expose `/logs/recent` API route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684668e6da10832092141131108f579e