### PR TITLE
Add usage metrics for models and incomplete responses

### DIFF
--- a/MODEL_USAGE_GUIDE.md
+++ b/MODEL_USAGE_GUIDE.md
@@ -15,3 +15,11 @@ tokens** por resposta. O DevAI envia `stream=True` para transmitir os tokens aos
 poucos; caso o modelo não ofereça streaming, o texto completo é retornado de uma
 única vez. Consulte [limitations.md](limitations.md) para detalhes e para
 entender eventuais variações observadas no endpoint `/analyze_deep`.
+
+## Estatísticas de uso
+
+O endpoint `/metrics` agora mostra contadores de chamadas por modelo e a
+porcentagem de respostas incompletas detectadas.  Use `model_usage` para
+avaliar a frequência de cada provedor configurado.  Os campos
+`error_percent` e `incomplete_percent` indicam, respectivamente, a taxa de
+falhas de API e de respostas que precisaram de recuperação por corte.

--- a/devai/ai_model.py
+++ b/devai/ai_model.py
@@ -330,6 +330,10 @@ class AIModel:
             fallback=fallback,
         )
 
+        metrics.record_model_usage(used_model)
+        if is_response_incomplete(response_text):
+            metrics.record_incomplete()
+
         self.cache.add(key, response_text)
         return annotation + response_text
 

--- a/devai/config.py
+++ b/devai/config.py
@@ -138,6 +138,8 @@ class Metrics:
         self.errors = 0
         self.max_cpu_percent = 0.0
         self.max_memory_percent = 0.0
+        self.model_usage: Dict[str, int] = {}
+        self.incomplete_responses = 0
 
     def record_call(self, duration: float):
         self.api_calls += 1
@@ -146,6 +148,12 @@ class Metrics:
 
     def record_error(self):
         self.errors += 1
+
+    def record_model_usage(self, name: str) -> None:
+        self.model_usage[name] = self.model_usage.get(name, 0) + 1
+
+    def record_incomplete(self) -> None:
+        self.incomplete_responses += 1
 
     def update_resources(self) -> None:
         if not psutil:
@@ -166,6 +174,10 @@ class Metrics:
             "errors": self.errors,
             "max_cpu_percent": self.max_cpu_percent,
             "max_memory_percent": self.max_memory_percent,
+            "model_usage": dict(self.model_usage),
+            "incomplete_responses": self.incomplete_responses,
+            "error_percent": (self.errors / self.api_calls * 100) if self.api_calls else 0,
+            "incomplete_percent": (self.incomplete_responses / self.api_calls * 100) if self.api_calls else 0,
         }
         if psutil:
             try:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,3 +5,5 @@ def test_summary_has_cpu_memory_keys():
     assert "api_calls" in data
     # CPU and memory keys may not be present if psutil is missing
     assert "cpu_percent" in data or "memory_percent" in data or True
+    assert "model_usage" in data
+    assert "incomplete_percent" in data


### PR DESCRIPTION
## Summary
- extend Metrics with model usage and incomplete response counters
- log selected model and truncated results in `AIModel.generate`
- expose new stats in `/metrics`
- document metric meanings in `MODEL_USAGE_GUIDE`
- test metrics output

## Testing
- `pytest -q tests/test_metrics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466f92b4e883209a1ee6efdefc7043