### PR TITLE
Add intent classifier training and CLI command

### DIFF
--- a/devai/cli.py
+++ b/devai/cli.py
@@ -260,6 +260,22 @@ async def cli_main(guided: bool = False):
                 elif user_input.startswith("/treinar_rlhf_auto"):
                     result = await run_scheduled_rlhf(ai.memory)
                     print(json.dumps(result, indent=2))
+                elif user_input.startswith("/train_intents"):
+                    path = user_input[len("/train_intents"):].strip() or "intent_samples.json"
+                    file_path = Path(path)
+                    if not file_path.exists():
+                        print("Arquivo de exemplos não encontrado")
+                    else:
+                        data = json.loads(file_path.read_text())
+                        samples = []
+                        for item in data:
+                            if isinstance(item, dict):
+                                samples.append((item.get("text", ""), item.get("intent", "")))
+                            elif isinstance(item, list) and len(item) == 2:
+                                samples.append((item[0], item[1]))
+                        from .intent_classifier import train_intent_model
+                        train_intent_model(samples)
+                        print("Modelo de intenções treinado")
                 elif user_input.startswith("/feedback "):
                     parts = user_input[len("/feedback "):].split(maxsplit=2)
                     if len(parts) < 3:

--- a/devai/intent_classifier.py
+++ b/devai/intent_classifier.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import List, Tuple
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None
+
+try:
+    from sklearn.linear_model import LogisticRegression
+except Exception:  # pragma: no cover - optional dependency
+    LogisticRegression = None
+
+from .config import config, logger
+from .memory import MemoryManager
+
+MODEL_FILE = Path("intent_model.pkl")
+
+_memory: MemoryManager | None = None
+_model: LogisticRegression | None = None
+
+
+def _get_memory() -> MemoryManager:
+    global _memory
+    if _memory is None:
+        _memory = MemoryManager(config.MEMORY_DB, config.EMBEDDING_MODEL, model=None, index=None)
+    return _memory
+
+
+def _load_model() -> LogisticRegression | None:
+    global _model
+    if _model is None and MODEL_FILE.exists():
+        with MODEL_FILE.open("rb") as f:
+            _model = pickle.load(f)
+    return _model
+
+
+def train_intent_model(samples: List[Tuple[str, str]]) -> None:
+    """Treina classificador de intenção e salva em intent_model.pkl."""
+    if LogisticRegression is None or np is None:
+        raise RuntimeError("sklearn/numpy não instalados")
+    mem = _get_memory()
+    X = [mem._get_embedding(text) for text, _ in samples]
+    y = [intent for _, intent in samples]
+    X = np.array(X)
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X, y)
+    with MODEL_FILE.open("wb") as f:
+        pickle.dump(clf, f)
+    logger.info("intent_model_trained", samples=len(samples))
+    global _model
+    _model = clf
+
+
+def predict_intent(text: str) -> str:
+    """Retorna a intenção prevista utilizando o modelo treinado."""
+    if np is None:
+        raise RuntimeError("numpy não instalado")
+    model = _load_model()
+    if model is None:
+        raise FileNotFoundError("intent_model.pkl not found")
+    mem = _get_memory()
+    vec = np.array([mem._get_embedding(text)])
+    return model.predict(vec)[0]

--- a/devai/intent_router.py
+++ b/devai/intent_router.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from typing import Dict
+from pathlib import Path
+
+from .intent_classifier import predict_intent
 
 INTENT_KEYWORDS: Dict[str, list[str]] = {
     "debug": ["erro", "stack", "bug", "falha"],
@@ -12,10 +15,20 @@ INTENT_KEYWORDS: Dict[str, list[str]] = {
 }
 
 
-def detect_intent(query: str) -> str:
-    """Simple rule-based intent detection."""
+def _keyword_intent(query: str) -> str:
     q = query.lower()
     for intent, kws in INTENT_KEYWORDS.items():
         if any(k in q for k in kws):
             return intent
     return "generic"
+
+
+def detect_intent(query: str) -> str:
+    """Return intent using model when available with keyword fallback."""
+    model_path = Path("intent_model.pkl")
+    if model_path.exists():
+        try:
+            return predict_intent(query)
+        except Exception:
+            pass
+    return _keyword_intent(query)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,3 +34,9 @@ O parâmetro `MAX_SESSION_TOKENS` controla a quantidade máxima de tokens mantid
 
 A classe `ConversationHandler` oferece o método `search_history(session_id, query)` que utiliza embeddings gravados em `memory.db` para localizar mensagens similares ao texto ou tag informados.
 
+## Classificador de intenções
+
+O arquivo `intent_samples.json` contém exemplos de frases e suas respectivas intenções. Adicione novos pares para ensinar o DevAI a reconhecer outras solicitações.
+
+Após atualizar esse arquivo, execute o comando `/train_intents` no CLI. O processo irá gerar `intent_model.pkl`, utilizado pelo roteador de intenções. Caso o modelo não exista, o DevAI continuará usando apenas o mapeamento por palavras‑chave.
+

--- a/intent_samples.json
+++ b/intent_samples.json
@@ -1,0 +1,9 @@
+[
+  {"text": "Ocorreu um erro ao rodar o código", "intent": "debug"},
+  {"text": "Crie um novo módulo de autenticação", "intent": "create"},
+  {"text": "Edite o arquivo de configuração", "intent": "edit"},
+  {"text": "Adicione testes unitários para a função", "intent": "tests"},
+  {"text": "Faça uma revisão do código da API", "intent": "review"},
+  {"text": "Como está a arquitetura do projeto?", "intent": "architecture"}
+]
+


### PR DESCRIPTION
## Summary
- implement `intent_classifier.py` with train/predict helpers
- add initial `intent_samples.json`
- extend `intent_router.detect_intent` to use the trained model
- add `/train_intents` command in CLI
- document how to customize and train intents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684676c9998883209f225ddb05444ab0