### PR TITLE
Improve tagging and memory statistics

### DIFF
--- a/MEMORY_STRUCTURE.md
+++ b/MEMORY_STRUCTURE.md
@@ -8,3 +8,14 @@ Campos principais:
 - `content`, `metadata`, `embedding`
 
 Consultas podem filtrar por `memory_type` usando o comando `/memoria tipo:<tag>`.
+
+Tags associadas a cada entrada ficam na tabela `tags`. Sempre que uma tag é
+registrada, seu contador em `tag_stats` é incrementado, permitindo analisar
+frequências de uso.
+
+Exemplos de tags geradas automaticamente:
+- `@nova_funcao`, `@refatorado` – controle de versões
+- `@complexo` – funções com complexidade acima do limiar definido em
+  `COMPLEXITY_TAG_THRESHOLD`
+- `@descontinuado` – detectado em docstrings contendo “deprecated” ou
+  “obsoleto”

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,7 @@ NOTIFY_EMAIL: ''
 # Caminho opcional para um modelo local da HuggingFace
 LOCAL_MODEL: ''
 COMPLEXITY_HISTORY: complexity_history.json
+COMPLEXITY_TAG_THRESHOLD: 10
 START_MODE: fast  # options: fast, full, custom
 START_TASKS: []  # aplica apenas se START_MODE = custom (scan, watch, monitor)
 RESCAN_INTERVAL_MINUTES: 15

--- a/devai/config.py
+++ b/devai/config.py
@@ -46,6 +46,7 @@ class Config:
     MAX_SESSION_TOKENS: int = 1000
     MAX_PROMPT_TOKENS: int = 1000
     COMPLEXITY_HISTORY: str = "complexity_history.json"
+    COMPLEXITY_TAG_THRESHOLD: int = 10
     LOG_AGGREGATOR_URL: str = os.getenv("LOG_AGGREGATOR_URL", "")
     DOUBLE_CHECK: bool = False
     SHOW_REASONING_BY_DEFAULT: bool = False
@@ -124,6 +125,8 @@ class Config:
             raise ValueError("RLHF_OUTPUT_DIR must be string")
         if not isinstance(self.MAX_PROMPT_TOKENS, int):
             raise ValueError("MAX_PROMPT_TOKENS must be integer")
+        if not isinstance(self.COMPLEXITY_TAG_THRESHOLD, int):
+            raise ValueError("COMPLEXITY_TAG_THRESHOLD must be integer")
 
     @property
     def model_name(self) -> str:

--- a/devai/symbolic_memory_tagger.py
+++ b/devai/symbolic_memory_tagger.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+from .config import config
 
 previous_hashes: Dict[str, str] = {}
 
@@ -19,4 +20,12 @@ def tag_memory_entry(metadata: Dict) -> List[str]:
     doc = metadata.get("docstring", "").lower()
     if "erro" in doc or "bug" in doc:
         tags.append("@erro_corrigido")
+    if "deprecated" in doc or "obsoleto" in doc:
+        tags.append("@descontinuado")
+    complexity = metadata.get("complexity")
+    try:
+        if float(complexity) > config.COMPLEXITY_TAG_THRESHOLD:
+            tags.append("@complexo")
+    except Exception:
+        pass
     return tags

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -161,3 +161,16 @@ def test_index_persistence(tmp_path, monkeypatch):
 
     mem2 = MemoryManager(db, "dummy", model=model, index=None)
     assert mem2.indexed_ids == mem1.indexed_ids
+
+
+def test_tag_stats(tmp_path):
+    db = str(tmp_path / "mem.sqlite")
+    mem = MemoryManager(db, "dummy", model=None, index=None)
+    mem.save({"type": "n", "content": "a", "metadata": {}, "tags": ["x", "y"]})
+    mem.save({"type": "n", "content": "b", "metadata": {}, "tags": ["x"]})
+    cur = mem.conn.cursor()
+    a = cur.execute("SELECT count FROM tag_stats WHERE tag='x'").fetchone()[0]
+    b = cur.execute("SELECT count FROM tag_stats WHERE tag='y'").fetchone()[0]
+    assert a == 2
+    assert b == 1
+

--- a/tests/test_memory_tagger.py
+++ b/tests/test_memory_tagger.py
@@ -7,3 +7,17 @@ def test_tag_memory_entry():
     tags2 = tag_memory_entry({"name": "f", "hash": "2"})
     assert "@nova_funcao" in tags1
     assert "@refatorado" in tags2
+
+
+def test_complexity_and_docstring_tags(monkeypatch):
+    previous_hashes.clear()
+    from devai.config import config
+    monkeypatch.setattr(config, "COMPLEXITY_TAG_THRESHOLD", 5)
+    tags = tag_memory_entry({
+        "name": "g",
+        "hash": "1",
+        "complexity": 6,
+        "docstring": "deprecated: old"
+    })
+    assert "@complexo" in tags
+    assert "@descontinuado" in tags


### PR DESCRIPTION
## Summary
- add `COMPLEXITY_TAG_THRESHOLD` config option
- tag entries as `@complexo` or `@descontinuado`
- store tag statistics in new `tag_stats` table
- increment tag usage counters on save
- document tagging and tag statistics
- test new tagging logic and stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467f94a8108320826d2ba200e0ccb4