### PR TITLE
Add configurable error log settings

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,8 @@ CODE_ROOT: ./app
 API_PORT: 8000
 LOG_DIR: ./logs
 LOG_MONITOR_INTERVAL: 60
+ERROR_LOG_PATH: errors_log.jsonl
+ERROR_LOG_MAX_LINES: 1000
 MODELS:
   default:
     name: deepseek/deepseek-r1-0528:free

--- a/devai/config.py
+++ b/devai/config.py
@@ -32,6 +32,8 @@ class Config:
     TASK_DEFINITIONS: str = "tasks.yaml"
     LOG_DIR: str = "./logs"
     LOG_MONITOR_INTERVAL: int = 60
+    ERROR_LOG_PATH: str = "errors_log.jsonl"
+    ERROR_LOG_MAX_LINES: int = 1000
     FILE_HISTORY: str = "file_history.json"
     API_SECRET: str = os.getenv("API_SECRET", "")
     API_PORT: int = 8000
@@ -123,6 +125,10 @@ class Config:
             raise ValueError("RLHF_THRESHOLD must be integer")
         if not isinstance(self.RLHF_OUTPUT_DIR, str):
             raise ValueError("RLHF_OUTPUT_DIR must be string")
+        if not isinstance(self.ERROR_LOG_PATH, str):
+            raise ValueError("ERROR_LOG_PATH must be string")
+        if not isinstance(self.ERROR_LOG_MAX_LINES, int):
+            raise ValueError("ERROR_LOG_MAX_LINES must be integer")
         if not isinstance(self.MAX_PROMPT_TOKENS, int):
             raise ValueError("MAX_PROMPT_TOKENS must be integer")
         if not isinstance(self.COMPLEXITY_TAG_THRESHOLD, int):

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,3 +40,13 @@ O arquivo `intent_samples.json` contém exemplos de frases e suas respectivas in
 
 Após atualizar esse arquivo, execute o comando `/train_intents` no CLI. O processo irá gerar `intent_model.pkl`, utilizado pelo roteador de intenções. Caso o modelo não exista, o DevAI continuará usando apenas o mapeamento por palavras‑chave.
 
+## Log de erros
+
+O DevAI mantém um histórico dos erros ocorridos em `ERROR_LOG_PATH`.
+Após cada execução, o arquivo é truncado para no máximo `ERROR_LOG_MAX_LINES` linhas para evitar crescimento indefinido.
+
+```yaml
+ERROR_LOG_PATH: errors_log.jsonl
+ERROR_LOG_MAX_LINES: 1000
+```
+

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+from devai.config import config
 from devai.error_handler import (
     with_retry_async,
     friendly_message,
@@ -57,6 +58,7 @@ def test_friendly_unknown():
 
 def test_persist_and_load_errors(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(config, "ERROR_LOG_PATH", str(tmp_path / "errors_log.jsonl"))
     error_memory.clear()
     log_error("unit_test", ValueError("boom"))
     asyncio.run(persist_errors())


### PR DESCRIPTION
## Summary
- add `ERROR_LOG_PATH` and `ERROR_LOG_MAX_LINES` to example config
- load the new settings in Config and validate them
- use config paths for error log persistence and truncate file
- document options in CONFIGURATION docs
- adjust unit tests for configurable path

## Testing
- `pytest -q 2>&1 | tee /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_684683aecff88320b01c7779e5d17667