### PR TITLE
Add complexity history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ Além das tarefas padrão, a CLI permite explorar e modificar o diretório defin
 - `/editar <arquivo> <linha> <novo>` altera uma linha individual.
 - `/tarefa auto_refactor <arquivo>` refatora o arquivo informado e executa os testes.
 
+### Histórico de complexidade
+
+Com o servidor API rodando é possível consultar `/complexity/history` para obter
+o histórico de variações de complexidade salvas em `complexity_history.json`.
+O endpoint retorna uma lista de registros e a tendência média recente:
+
+```json
+{
+  "history": [{"timestamp": "2024-01-01T12:00:00", "average_complexity": 3.2}],
+  "trend": -0.1
+}
+```
+
+Valores negativos de `trend` indicam redução da complexidade média do projeto.
+
 ## Testes
 
 Instale as dependências de desenvolvimento e execute:

--- a/devai/complexity_tracker.py
+++ b/devai/complexity_tracker.py
@@ -35,3 +35,16 @@ class ComplexityTracker:
 
     def get_history(self) -> List[Dict[str, float]]:
         return list(self.history)
+
+    def summarize_trend(self, window: int = 5) -> float:
+        """Return the average change between the last ``window`` records."""
+        if window < 2:
+            window = 2
+        records = self.history[-window:]
+        if len(records) < 2:
+            return 0.0
+        diffs = [
+            b["average_complexity"] - a["average_complexity"]
+            for a, b in zip(records, records[1:])
+        ]
+        return sum(diffs) / len(diffs)

--- a/devai/core.py
+++ b/devai/core.py
@@ -646,6 +646,12 @@ class CodeMemoryAI:
             ]
             return rows
 
+        @self.app.get("/complexity/history")
+        async def complexity_history(limit: int = 100, window: int = 5):
+            history = self.complexity_tracker.get_history()[-limit:]
+            trend = self.complexity_tracker.summarize_trend(window)
+            return {"history": history, "trend": trend}
+
         @self.app.get("/metacognition/summary")
         async def metacognition_summary():
             path = Path("devai/meta/score_map.json")

--- a/tests/test_complexity_history.py
+++ b/tests/test_complexity_history.py
@@ -1,0 +1,55 @@
+import asyncio
+import types
+from datetime import datetime
+from devai.core import CodeMemoryAI
+from devai.conversation_handler import ConversationHandler
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None, temperature=0.0):
+        return "ok"
+
+class DummyTracker:
+    def __init__(self, hist, trend):
+        self._hist = hist
+        self._trend = trend
+    def get_history(self):
+        return self._hist
+    def summarize_trend(self, window=5):
+        return self._trend
+
+
+def _setup_ai(history, trend):
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
+    ai.analyzer = types.SimpleNamespace(graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now())
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.reason_stack = []
+    ai.double_check = False
+    ai.complexity_tracker = DummyTracker(history, trend)
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_get(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = app.post = fake_get
+    app.mount = lambda *a, **k: None
+    ai.app = app
+    CodeMemoryAI._setup_api_routes(ai)
+    return record
+
+
+def test_complexity_history_endpoint():
+    history = [
+        {"timestamp": "t1", "average_complexity": 1.0},
+        {"timestamp": "t2", "average_complexity": 2.0},
+    ]
+    trend = 0.5
+    record = _setup_ai(history, trend)
+    fn = record["/complexity/history"]
+    result = asyncio.run(fn())
+    assert result["history"] == history
+    assert result["trend"] == trend


### PR DESCRIPTION
## Summary
- extend `ComplexityTracker` with trend calculation
- expose `/complexity/history` endpoint
- document complexity history API
- add tests for new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684686f0143c8320acb91fb7a01dfa47