### PR TITLE
Maintain conversation embedding cleanup

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -32,7 +32,7 @@ Quando `TESTS_USE_ISOLATION` for `true`, o DevAI executará `pytest` em um conta
 
 O parâmetro `MAX_SESSION_TOKENS` controla a quantidade máxima de tokens mantidos no arquivo de histórico de cada sessão. Ao exceder esse limite, as mensagens mais antigas são removidas (pruning). Defina `0` para desabilitar a limpeza automática.
 
-A classe `ConversationHandler` oferece o método `search_history(session_id, query)` que utiliza embeddings gravados em `memory.db` para localizar mensagens similares ao texto ou tag informados.
+A classe `ConversationHandler` oferece o método `search_history(session_id, query)` que utiliza embeddings gravados em `memory.db` para localizar mensagens similares ao texto ou tag informados. Os embeddings de mensagens descartadas também são removidos do banco, evitando acúmulo de vetores antigos.
 
 ## Classificador de intenções
 


### PR DESCRIPTION
## Summary
- purge pruned embeddings from `conversation_embeddings`
- clear embeddings on session reset and clear_session
- document automatic cleanup of these vectors

## Testing
- `flake8` *(fails: command not found)*
- `bandit -r devai` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468b8b66a48320b91983818eec9ab0