### PR TITLE
Async summarizer

### DIFF
--- a/devai/conversation_handler.py
+++ b/devai/conversation_handler.py
@@ -128,7 +128,7 @@ class ConversationHandler:
             if wait > 0:
                 await asyncio.sleep(wait)
             try:
-                summary = self.summarizer.summarize_conversation(hist, self.memory)
+                summary = await self.summarizer.summarize_conversation(hist, self.memory)
                 if summary and self.memory:
                     for item in summary:
                         try:

--- a/devai/dialog_summarizer.py
+++ b/devai/dialog_summarizer.py
@@ -17,7 +17,7 @@ from .memory import MemoryManager
 class DialogSummarizer:
     """Extract symbolic memories from conversation history."""
 
-    def summarize_conversation(
+    async def summarize_conversation(
         self,
         history: List[Dict[str, Any]],
         memory: Optional[MemoryManager] = None,
@@ -91,7 +91,7 @@ class DialogSummarizer:
                         finally:
                             await ai.close()
 
-                    resp = asyncio.run(_call())
+                    resp = await _call()
                     extracted: List[Dict[str, str]] = []
                     for line in resp.splitlines():
                         m = re.match(r"-?\s*(#[\w_]+)[:\-]?\s*(.*)", line.strip())

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,6 +34,8 @@ O parâmetro `MAX_SESSION_TOKENS` controla a quantidade máxima de tokens mantid
 
 A classe `ConversationHandler` oferece o método `search_history(session_id, query)` que utiliza embeddings gravados em `memory.db` para localizar mensagens similares ao texto ou tag informados. Os embeddings de mensagens descartadas também são removidos do banco, evitando acúmulo de vetores antigos.
 
+O resumo periódico das conversas executado pelo `DialogSummarizer` agora é assíncrono. Métodos como `summarize_conversation()` e a rotina interna `_summarize_and_store()` do `ConversationHandler` são `async` e devem ser aguardados quando chamados diretamente.
+
 ## Classificador de intenções
 
 O arquivo `intent_samples.json` contém exemplos de frases e suas respectivas intenções. Adicione novos pares para ensinar o DevAI a reconhecer outras solicitações.

--- a/tests/test_dialog_summarizer.py
+++ b/tests/test_dialog_summarizer.py
@@ -1,3 +1,4 @@
+import asyncio
 from devai.dialog_summarizer import DialogSummarizer
 from devai import dialog_summarizer
 from devai.config import config
@@ -13,7 +14,7 @@ def test_dialog_summarizer_basic():
         {"role": "assistant", "content": "beleza"},
     ]
     summarizer = DialogSummarizer()
-    summary = summarizer.summarize_conversation(history)
+    summary = asyncio.run(summarizer.summarize_conversation(history))
     assert any(m["tag"] == "#licao_aprendida" for m in summary)
     assert any(s["content"].endswith("por razões de segurança.") for s in summary)
     tags = {m["tag"] for m in summary}
@@ -45,7 +46,7 @@ def test_dialog_summarizer_ai_fallback(monkeypatch):
             saved.append(item)
 
     summarizer = DialogSummarizer()
-    summarizer.summarize_conversation(history, memory=DummyMemory())
+    asyncio.run(summarizer.summarize_conversation(history, memory=DummyMemory()))
 
     assert DummyModel.called == 1
     assert saved


### PR DESCRIPTION
## Summary
- refactor `DialogSummarizer.summarize_conversation` into an async method
- await the summarizer inside `ConversationHandler._summarize_and_store`
- adjust summarizer tests to run in an event loop
- document the asynchronous behaviour for conversation history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468d1612108320a9731a775e1fc407