### PR TITLE
Add RLHF dataset hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ python -m devai.rlhf <modelo_base> ./model_ft
 
 O comando coleta os exemplos do banco de memória, monta um pequeno dataset supervisionado e chama o `SFTTrainer` da `trl`. Os checkpoints do modelo e o arquivo `metrics.json` são gravados no diretório indicado.
 
+O dataset combinado é salvo em `logs/rlhf_dataset.json` e um arquivo com o hash
+SHA256 é criado em `logs/rlhf_results/datasets/`. O treinamento programado só é
+executado quando esse hash muda.
+
 ### Integração contínua
 
 O repositório inclui um workflow em `.github/workflows/ci.yml` que executa lint, análise de segurança e testes a cada *pull request*. Basta habilitar o GitHub Actions para que as tarefas sejam rodadas automaticamente.


### PR DESCRIPTION
## Summary
- generate SHA256 for collected RLHF examples
- track dataset hashes in `logs/rlhf_results/datasets`
- skip scheduled RLHF training when the hash hasn't changed
- record training metadata in memory
- document dataset and hash locations
- update tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68468ea9d8248320974f5f2994c32fe9