### PR TITLE
Add complexity threshold to AutoReview

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,7 @@ NOTIFY_EMAIL: ''
 LOCAL_MODEL: ''
 COMPLEXITY_HISTORY: complexity_history.json
 COMPLEXITY_TAG_THRESHOLD: 10
+AUTO_REVIEW_COMPLEXITY_THRESHOLD: 10
 START_MODE: fast  # options: fast, full, custom
 START_TASKS: []  # aplica apenas se START_MODE = custom (scan, watch, monitor)
 RESCAN_INTERVAL_MINUTES: 15

--- a/devai/auto_review.py
+++ b/devai/auto_review.py
@@ -1,25 +1,51 @@
 from typing import Dict, List
 
-from .config import logger
+from .config import logger, config
 from .analyzer import CodeAnalyzer
 from .memory import MemoryManager
+from .complexity_tracker import ComplexityTracker
 
 
 async def run_autoreview(analyzer: CodeAnalyzer, memory: MemoryManager) -> Dict[str, List[str]]:
     """Scan project and suggest symbolic refactors."""
     undocumented = [n for n, c in analyzer.code_chunks.items() if not c.get("docstring")]
     unused = [n for n in analyzer.code_chunks if analyzer.code_graph.out_degree(n) == 0]
+    threshold = config.AUTO_REVIEW_COMPLEXITY_THRESHOLD
+    complex_funcs = [
+        n
+        for n, c in analyzer.code_chunks.items()
+        if c.get("complexity", 0) > threshold
+    ]
+    complexities = [c.get("complexity", 0) for c in analyzer.code_chunks.values()]
+    avg_complexity = sum(complexities) / len(complexities) if complexities else 0
+    ComplexityTracker(config.COMPLEXITY_HISTORY).record(avg_complexity)
+
     suggestions: List[str] = []
     if undocumented:
         suggestions.append(f"Funcoes sem docstring: {', '.join(undocumented[:5])}")
     if unused:
         suggestions.append(f"Possiveis funcoes nao utilizadas: {', '.join(unused[:5])}")
-    memory.save({
-        "type": "autoreview",
-        "content": "AutoReview executado",
-        "metadata": {"undocumented": undocumented, "unused": unused},
-        "tags": ["autoreview"],
-        "context_level": "short",
-    })
-    logger.info("AutoReview executado", undocumented=len(undocumented), unused=len(unused))
+    if complex_funcs:
+        suggestions.append(f"Funcoes complexas: {', '.join(complex_funcs[:5])}")
+
+    memory.save(
+        {
+            "type": "autoreview",
+            "content": "AutoReview executado",
+            "metadata": {
+                "undocumented": undocumented,
+                "unused": unused,
+                "complex": complex_funcs,
+                "avg_complexity": avg_complexity,
+            },
+            "tags": ["autoreview"],
+            "context_level": "short",
+        }
+    )
+    logger.info(
+        "AutoReview executado",
+        undocumented=len(undocumented),
+        unused=len(unused),
+        complex=len(complex_funcs),
+    )
     return {"suggestions": suggestions}

--- a/devai/config.py
+++ b/devai/config.py
@@ -49,6 +49,7 @@ class Config:
     MAX_PROMPT_TOKENS: int = 1000
     COMPLEXITY_HISTORY: str = "complexity_history.json"
     COMPLEXITY_TAG_THRESHOLD: int = 10
+    AUTO_REVIEW_COMPLEXITY_THRESHOLD: int = 10
     LOG_AGGREGATOR_URL: str = os.getenv("LOG_AGGREGATOR_URL", "")
     DOUBLE_CHECK: bool = False
     SHOW_REASONING_BY_DEFAULT: bool = False
@@ -133,6 +134,8 @@ class Config:
             raise ValueError("MAX_PROMPT_TOKENS must be integer")
         if not isinstance(self.COMPLEXITY_TAG_THRESHOLD, int):
             raise ValueError("COMPLEXITY_TAG_THRESHOLD must be integer")
+        if not isinstance(self.AUTO_REVIEW_COMPLEXITY_THRESHOLD, int):
+            raise ValueError("AUTO_REVIEW_COMPLEXITY_THRESHOLD must be integer")
 
     @property
     def model_name(self) -> str:

--- a/tests/test_autoreview_complexity.py
+++ b/tests/test_autoreview_complexity.py
@@ -1,0 +1,41 @@
+import asyncio
+import types
+
+import devai.auto_review as auto_review
+from devai.config import config
+
+class DummyTracker:
+    def __init__(self, *a, **k):
+        self.recorded = []
+    def record(self, value):
+        self.recorded.append(value)
+
+
+def test_autoreview_complexity(monkeypatch):
+    monkeypatch.setattr(config, "AUTO_REVIEW_COMPLEXITY_THRESHOLD", 5)
+    tracker = DummyTracker()
+    monkeypatch.setattr(auto_review, "ComplexityTracker", lambda *a, **k: tracker)
+
+    analyzer = types.SimpleNamespace(
+        code_chunks={
+            "f1": {"docstring": "", "complexity": 4},
+            "f2": {"docstring": "ok", "complexity": 7},
+        },
+        code_graph=types.SimpleNamespace(out_degree=lambda n: 1),
+    )
+
+    class Mem:
+        def __init__(self):
+            self.saved = []
+        def save(self, entry):
+            self.saved.append(entry)
+
+    memory = Mem()
+
+    async def run():
+        return await auto_review.run_autoreview(analyzer, memory)
+
+    result = asyncio.run(run())
+    assert any("Funcoes complexas" in s for s in result["suggestions"])
+    assert memory.saved[0]["metadata"]["complex"] == ["f2"]
+    assert tracker.recorded and tracker.recorded[0] == (4 + 7) / 2


### PR DESCRIPTION
## Summary
- monitor average complexity via `ComplexityTracker` when running AutoReview
- warn about complex functions above `AUTO_REVIEW_COMPLEXITY_THRESHOLD`
- persist complexity info in AutoReview metadata
- expose `AUTO_REVIEW_COMPLEXITY_THRESHOLD` in config
- test new complexity suggestions

## Testing
- `pytest -q`
- `pytest tests/test_autoreview_complexity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68469c5866b08320b4997908c76c8458