### PR TITLE
Implement Slack notifications for Notifier

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,6 +11,8 @@ MODELS:
     url: https://openrouter.ai/api/v1/chat/completions
 # E-mail para notificações (opcional)
 NOTIFY_EMAIL: ''
+# Webhook Slack para notificações (opcional)
+NOTIFY_SLACK: ''
 # Caminho opcional para um modelo local da HuggingFace
 LOCAL_MODEL: ''
 COMPLEXITY_HISTORY: complexity_history.json

--- a/devai/config.py
+++ b/devai/config.py
@@ -44,6 +44,7 @@ class Config:
     INDEX_FILE: str = "faiss.index"
     INDEX_IDS_FILE: str = "faiss_ids.json"
     NOTIFY_EMAIL: str = os.getenv("NOTIFY_EMAIL", "")
+    NOTIFY_SLACK: str = os.getenv("NOTIFY_SLACK", "")
     LOCAL_MODEL: str = os.getenv("LOCAL_MODEL", "")
     MAX_SESSION_TOKENS: int = 1000
     MAX_PROMPT_TOKENS: int = 1000

--- a/devai/notifier.py
+++ b/devai/notifier.py
@@ -1,24 +1,51 @@
+import asyncio
 import smtplib
 from email.message import EmailMessage
+import aiohttp
 from .config import config, logger
 
 class Notifier:
-    """Simple email notifier."""
+    """Simple notifier for email and Slack."""
 
     def __init__(self):
-        self.enabled = bool(getattr(config, "NOTIFY_EMAIL", ""))
+        self.email_enabled = bool(getattr(config, "NOTIFY_EMAIL", ""))
+        self.slack_url = getattr(config, "NOTIFY_SLACK", "")
+        self.enabled = self.email_enabled or bool(self.slack_url)
+
+    async def _send_slack(self, text: str) -> None:
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=10)
+            ) as session:
+                await session.post(self.slack_url, json={"text": text})
+            logger.info("Notificação Slack enviada")
+        except Exception as e:  # pragma: no cover - notification failures tolerated
+            logger.error("Falha ao enviar Slack", error=str(e))
+
+    def _run_async(self, coro) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(coro)
+        else:
+            loop.create_task(coro)
 
     def send(self, subject: str, body: str) -> None:
         if not self.enabled:
             return
-        try:
-            msg = EmailMessage()
-            msg["Subject"] = subject
-            msg["From"] = config.NOTIFY_EMAIL
-            msg["To"] = config.NOTIFY_EMAIL
-            msg.set_content(body)
-            with smtplib.SMTP("localhost") as s:
-                s.send_message(msg)
-            logger.info("Notificação enviada")
-        except Exception as e:  # pragma: no cover - notification failures tolerated
-            logger.error("Falha ao enviar notificação", error=str(e))
+        if self.email_enabled:
+            try:
+                msg = EmailMessage()
+                msg["Subject"] = subject
+                msg["From"] = config.NOTIFY_EMAIL
+                msg["To"] = config.NOTIFY_EMAIL
+                msg.set_content(body)
+                with smtplib.SMTP("localhost") as s:
+                    s.send_message(msg)
+                logger.info("Notificação enviada")
+            except Exception as e:  # pragma: no cover - notification failures tolerated
+                logger.error("Falha ao enviar notificação", error=str(e))
+
+        if self.slack_url:
+            text = f"*{subject}*\n{body}"
+            self._run_async(self._send_slack(text))

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -52,3 +52,14 @@ ERROR_LOG_PATH: errors_log.jsonl
 ERROR_LOG_MAX_LINES: 1000
 ```
 
+## Notificações
+
+Para receber avisos automáticos, defina um e-mail ou um webhook do Slack:
+
+```yaml
+NOTIFY_EMAIL: ''       # opcional
+NOTIFY_SLACK: ''       # opcional
+```
+
+Quando configurados, ambos os canais serão utilizados.
+

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,48 @@
+import asyncio
+from devai.notifier import Notifier
+from devai.config import config
+
+class DummySMTP:
+    def __init__(self, host):
+        self.host = host
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def send_message(self, msg):
+        DummySMTP.sent.append(msg)
+
+DummySMTP.sent = []
+
+class DummySession:
+    def __init__(self, *a, **k):
+        pass
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def post(self, url, json):
+        DummySession.posts.append((url, json))
+        class Resp:
+            async def json(self):
+                return {}
+            async def text(self):
+                return ""
+        return Resp()
+
+DummySession.posts = []
+
+def test_send_email_and_slack(monkeypatch):
+    DummySMTP.sent = []
+    DummySession.posts = []
+    monkeypatch.setattr(config, "NOTIFY_EMAIL", "user@example.com", raising=False)
+    monkeypatch.setattr(config, "NOTIFY_SLACK", "http://hook", raising=False)
+    monkeypatch.setattr("smtplib.SMTP", lambda host: DummySMTP(host))
+    monkeypatch.setattr("aiohttp.ClientSession", DummySession)
+
+    notifier = Notifier()
+    notifier.send("Alerta", "Teste")
+
+    assert DummySMTP.sent
+    assert DummySMTP.sent[0]["Subject"] == "Alerta"
+    assert DummySession.posts == [("http://hook", {"text": "*Alerta*\nTeste"})]


### PR DESCRIPTION
## Summary
- support Slack webhooks in `Notifier`
- add `NOTIFY_SLACK` configuration option
- document the new notifications config
- update example configuration file
- add tests covering email and Slack notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469e4790308320b0bcee2ed2a9883f