### PR TITLE
Fix SQLite thread usage

### DIFF
--- a/devai/feedback.py
+++ b/devai/feedback.py
@@ -10,7 +10,7 @@ class FeedbackDB:
     """Simple feedback registry."""
 
     def __init__(self, db_file: str = "feedback.db") -> None:
-        self.conn = sqlite3.connect(db_file)
+        self.conn = sqlite3.connect(db_file, check_same_thread=False)
         self._init_db()
 
     def _init_db(self) -> None:

--- a/devai/memory.py
+++ b/devai/memory.py
@@ -51,7 +51,7 @@ class MemoryManager:
         index: Optional[Any] = None,
         cache_size: int = 128,
     ):
-        self.conn = sqlite3.connect(db_file)
+        self.conn = sqlite3.connect(db_file, check_same_thread=False)
         self.feedback_db = FeedbackDB()
         self._init_db()
         if model is None:

--- a/devai/plugin_manager.py
+++ b/devai/plugin_manager.py
@@ -14,7 +14,7 @@ class PluginManager:
         self.plugins: Dict[str, Any] = {}
         self.plugin_tasks: Dict[str, Set[str]] = {}
         self.plugin_paths: Dict[str, pathlib.Path] = {}
-        self.conn = sqlite3.connect(db_file)
+        self.conn = sqlite3.connect(db_file, check_same_thread=False)
         self._init_db()
         self.load_plugins()
 


### PR DESCRIPTION
## Summary
- allow cross-thread SQLite access for memory, feedback, and plugin DBs

## Testing
- `pre-commit` *(failed: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465cb0dbb08320ae2dfbf8853ab1d3