### PR TITLE
Document Rich CLI interface

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -2,6 +2,16 @@
 
 Este documento descreve os comandos simbólicos disponíveis no DevAI via CLI. Todos eles produzem mensagens simbólicas e estão preparados para integração futura ao painel visual.
 
+Ao iniciar a CLI com `python -m devai --cli` é apresentada uma interface colorida baseada em Rich. Um terminal simples pode usar `--plain`.
+
+Exemplo:
+
+```
+┌─ DevAI ──────────────┐
+│ >>> /rastrear app.py │
+└──────────────────────┘
+```
+
 ## /lembrar <conteúdo> [tipo:<tag>]
 Armazena uma memória manualmente na base vetorial. Opcionalmente é possível definir uma tag de tipo.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ API_SECRET: "sua-chave"
    variável diretamente no ambiente. O DevAI carrega esse arquivo
    automaticamente se o pacote `python-dotenv` estiver instalado.
 
-3. Instale as dependências do projeto para habilitar a comunicação real com o OpenRouter:
+3. Instale as dependências do projeto para habilitar a comunicação real com o OpenRouter. A nova interface interativa usa `rich` e `prompt_toolkit`:
 
 ```bash
 pip install -r requirements.txt
@@ -81,6 +81,21 @@ Com o servidor ativo, acesse `http://localhost:8000/static/index.html` para util
 
 ```bash
 python -m devai --cli
+```
+
+Por padrão a CLI utiliza a interface colorida do [Rich](https://github.com/Textualize/rich). Para um terminal mais simples use a flag `--plain`.
+
+Atalhos comuns:
+- setas **↑/↓** percorrem o histórico de comandos;
+- **Tab** autocompleta nomes e caminhos.
+
+Exemplo de tela:
+
+```
+┌─ DevAI ───────────────────────┐
+│ >>> /memoria                 │
+│ Resultado destacado em cores  │
+└───────────────────────────────┘
 ```
 
 Os comandos disponíveis na CLI são listados ao iniciar o programa, como `/memoria`, `/tarefa` e `/grafo`. Para refatorar um arquivo automaticamente utilize:

--- a/UI_roadmap.md
+++ b/UI_roadmap.md
@@ -4,5 +4,7 @@ A área de console agora exibe o plano de raciocínio retornado pelo endpoint
 `/analyze_deep`. A separação visual depende do modelo seguir corretamente a
 marcação `===RESPOSTA===`. Se falhas frequentes ocorrerem, essa divisão poderá
 ser revertida até que a IA tenha comportamento estável.
-\n- DONE: relatório do /deep_analysis agora colore linhas conforme severidade.
+
+- DONE: relatório do /deep_analysis agora colore linhas conforme severidade.
 - DONE: marcação `===RESPOSTA===` interpretada mesmo com espaços extras.
+- Se `rich` falhar ou não estiver instalado, a CLI automaticamente usa o modo `--plain`.

--- a/ui_fallbacks.md
+++ b/ui_fallbacks.md
@@ -3,5 +3,6 @@
 - Quando o DevAI é executado sem frontend web, as dicas de tooltips e o botão "Ajuda" não são exibidos.
 - Utilize a opção `--help` na CLI para ver um resumo das funções disponíveis.
 - Em execução via terminal, as funções avançadas continuam acessíveis pelo menu textual tradicional.
+- Caso a biblioteca `rich` não esteja presente, a CLI entra em modo `--plain` automaticamente.
 - # FUTURE: exibir mensagens contextuais a cada comando executado.
 - Em telas muito pequenas ou navegadores antigos, os botões são empilhados automaticamente para evitar cortes de texto.


### PR DESCRIPTION
## Summary
- document extra UI deps in README
- show Rich CLI example and shortcuts
- document Rich UI launch in command reference
- note CLI fallback behaviour in roadmap docs

## Testing
- `pytest -vv | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6846c2039cc883208cbac44de5b3d98b