### PR TITLE
Add diff detection in CLI

### DIFF
--- a/devai/cli.py
+++ b/devai/cli.py
@@ -334,7 +334,13 @@ async def cli_main(guided: bool = False, plain: bool = False):
                     async with ui.loading("Gerando resposta..."):
                         response = await ai.generate_response(user_input, double_check=ai.double_check)
                     print("\nResposta:")
-                    if plain:
+                    is_patch = bool(
+                        re.search(r"\ndiff --git", response)
+                        or re.search(r"^[+-](?![+-])", response, re.MULTILINE)
+                    )
+                    if is_patch:
+                        ui.render_diff(response)
+                    elif plain:
                         print(response)
                     else:
                         ui.console.print(response)


### PR DESCRIPTION
## Summary
- detect diff/patch output in `cli_main`
- render diffs using `ui.render_diff`
- test CLI diff rendering for patch text

## Testing
- `pytest tests/test_cli.py::test_cli_render_diff -q`
- `pytest tests/test_cli.py::test_cli_render_diff_plusminus -q`


------
https://chatgpt.com/codex/tasks/task_e_6846c525b0448320a15804fd85c3c0cc