### PR TITLE
Add persistent chat logs to CLI

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -19,6 +19,7 @@ def main():
     parser.add_argument("--cli", action="store_true", help="Inicia a interface de linha de comando")
     parser.add_argument("--guided", action="store_true", help="Mostra orientações passo a passo")
     parser.add_argument("--plain", action="store_true", help="Interface simples sem Rich")
+    parser.add_argument("--no-log", action="store_true", help="Não registra histórico de chat")
     parser.add_argument("--observer", action="store_true", help="Modo observador passivo")
     parser.add_argument("command", nargs="*", help="Comandos adicionais")
     args = parser.parse_args()
@@ -42,7 +43,7 @@ def main():
         asyncio.run(run_observer())
         return
     if args.cli:
-        asyncio.run(cli_main(guided=args.guided, plain=args.plain))
+        asyncio.run(cli_main(guided=args.guided, plain=args.plain, log=not args.no_log))
         return
 
     if args.command:

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -13,7 +13,7 @@ from .ui import CLIUI
 from rich.panel import Panel
 
 
-async def cli_main(guided: bool = False, plain: bool = False):
+async def cli_main(guided: bool = False, plain: bool = False, log: bool = True):
     """Interactive command loop for DevAI.
 
     Comandos principais: /lembrar, /esquecer, /ajustar, /rastrear e /memoria.
@@ -49,7 +49,8 @@ async def cli_main(guided: bool = False, plain: bool = False):
         "/preferencia",
         "/sair",
     ]
-    ui = CLIUI(plain=plain, commands=commands)
+    ui = CLIUI(plain=plain, commands=commands, log=log)
+    ui.load_history()
     run_scan = False
     if config.START_MODE == "full":
         run_scan = True


### PR DESCRIPTION
## Summary
- extend `CLIUI` to optionally log history to `~/.devai_chat.log`
- preload last lines from the log on startup
- add `--no-log` flag for cli
- persist conversation history during CLI usage
- test that history is persisted and flag works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c96648ec8320b0ea63e99194979e