### PR TITLE
Add Textual-based TUI option

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -17,6 +17,7 @@ def main():
     parser = argparse.ArgumentParser(description="CodeMemoryAI - Assistente de Código Inteligente")
     parser.add_argument("--api", action="store_true", help="Inicia o servidor API")
     parser.add_argument("--cli", action="store_true", help="Inicia a interface de linha de comando")
+    parser.add_argument("--tui", action="store_true", help="Inicia a interface textual")
     parser.add_argument("--guided", action="store_true", help="Mostra orientações passo a passo")
     parser.add_argument("--plain", action="store_true", help="Interface simples sem Rich")
     parser.add_argument("--no-log", action="store_true", help="Não registra histórico de chat")
@@ -42,8 +43,15 @@ def main():
 
         asyncio.run(run_observer())
         return
-    if args.cli:
-        asyncio.run(cli_main(guided=args.guided, plain=args.plain, log=not args.no_log))
+    if args.cli or args.tui:
+        asyncio.run(
+            cli_main(
+                guided=args.guided,
+                plain=args.plain,
+                log=not args.no_log,
+                tui=args.tui,
+            )
+        )
         return
 
     if args.command:

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -10,10 +10,19 @@ from pathlib import Path
 import re
 
 from .ui import CLIUI
+try:
+    from .tui import TUIApp
+except Exception:  # pragma: no cover - optional dependency
+    TUIApp = None  # type: ignore
 from rich.panel import Panel
 
 
-async def cli_main(guided: bool = False, plain: bool = False, log: bool = True):
+async def cli_main(
+    guided: bool = False,
+    plain: bool = False,
+    log: bool = True,
+    tui: bool = False,
+):
     """Interactive command loop for DevAI.
 
     Comandos principais: /lembrar, /esquecer, /ajustar, /rastrear e /memoria.
@@ -51,6 +60,10 @@ async def cli_main(guided: bool = False, plain: bool = False, log: bool = True):
     ]
     ui = CLIUI(plain=plain, commands=commands, log=log)
     ui.load_history()
+    if tui and not plain and TUIApp is not None:
+        app = TUIApp(ai=ai, cli_ui=ui, log=log)
+        app.run()
+        return
     run_scan = False
     if config.START_MODE == "full":
         run_scan = True

--- a/devai/tui.py
+++ b/devai/tui.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Input, TextLog
+
+from .core import CodeMemoryAI
+from .ui import CLIUI
+
+
+class TUIApp(App):
+    """Simple Textual-based UI for DevAI."""
+
+    BINDINGS = [("enter", "submit", "Enviar"), ("ctrl+c", "quit", "Sair")]
+
+    def __init__(self, ai: CodeMemoryAI | None = None, cli_ui: CLIUI | None = None, *, log: bool = True) -> None:
+        super().__init__()
+        self.ai = ai or CodeMemoryAI()
+        self.cli = cli_ui or CLIUI(plain=False, commands=None, log=log)
+        # Reuse the console from Textual
+        self.cli.console = self.console
+        self.history_panel: TextLog
+        self.diff_panel: TextLog
+        self.input: Input
+
+    def compose(self) -> ComposeResult:
+        self.history_panel = TextLog(highlight=False, name="history")
+        self.input = Input(placeholder="Digite um comando...", name="input")
+        left = Vertical(self.history_panel, self.input)
+        self.diff_panel = TextLog(highlight=True, name="diff")
+        yield Horizontal(left, self.diff_panel)
+
+    async def on_mount(self) -> None:
+        self.cli.load_history()
+        for line in self.cli.history:
+            self.history_panel.write(line)
+
+    async def action_submit(self) -> None:
+        text = self.input.value.strip()
+        if not text:
+            return
+        self.input.value = ""
+        self.cli.add_history(f">>> {text}")
+        self.history_panel.write(f">>> {text}")
+        if text.lower() == "/sair":
+            await self.action_quit()
+            return
+        async with self.cli.loading("Gerando resposta..."):
+            response = await self.ai.generate_response(text, double_check=self.ai.double_check)
+        self.cli.add_history(response)
+        self.history_panel.write(response)
+        is_patch = bool(
+            re.search(r"\ndiff --git", response)
+            or re.search(r"^[+-](?![+-])", response, re.MULTILINE)
+        )
+        if is_patch:
+            self.diff_panel.clear()
+            self.cli.render_diff(response)
+            self.diff_panel.write(response)
+        else:
+            self.diff_panel.clear()
+
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ python-dotenv
 # UI dependencies
 rich
 prompt_toolkit
+textual
 # Optional: treinamento RLHF
 trl>=0.7


### PR DESCRIPTION
## Summary
- register `textual` dependency
- introduce `TUIApp` using textual
- allow CLI to launch TUI when requested
- expose `--tui` flag in `__main__`
- keep plain mode and existing CLI behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d2ba30e88320b1067d566018d5f9