### PR TITLE
Implement CLI deletion confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,13 @@ Além das tarefas padrão, a CLI permite explorar e modificar o diretório defin
 - `/ls [caminho]` lista arquivos e subpastas.
 - `/abrir <arquivo> [ini] [fim]` exibe linhas específicas de um arquivo.
 - `/editar <arquivo> <linha> <novo>` altera uma linha individual.
+- `/novoarq <arquivo> [conteudo]` cria um novo arquivo.
+- `/novapasta <caminho>` cria uma pasta.
+- `/deletar <caminho>` remove arquivo ou diretório (requer confirmação).
 - `/tarefa auto_refactor <arquivo>` refatora o arquivo informado e executa os testes.
 - `/historia [sessao]` exibe o histórico de conversa da sessão indicada.
+
+Ao usar `/deletar`, a CLI exibe um diálogo de confirmação para evitar remoções acidentais.
 
 ### Histórico de complexidade
 

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -218,10 +218,8 @@ async def cli_main(
                     print("✅ Pasta criada" if ok else "Falha ao criar pasta")
                 elif user_input.startswith("/deletar "):
                     path = user_input[len("/deletar ") :].strip()
-                    confirm = (
-                        await ui.read_command("Tem certeza que deseja remover? [s/N] ")
-                    ).lower()
-                    if confirm != "s":
+                    confirmed = await ui.confirm("Tem certeza que deseja remover?")
+                    if not confirmed:
                         print("Operação cancelada")
                         continue
                     ok = await ai.analyzer.delete_file(path)


### PR DESCRIPTION
## Summary
- add CLIUI.confirm() with Textual/Rich fallback
- use confirm() for /deletar command
- document deletion confirmation in README
- update CLI tests with new confirmation behavior

## Testing
- `pytest -q tests/test_cli.py::test_cli_deletar_confirm`
- `pytest -q tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6846d52bfe788320b40bb70b7b25661a