### PR TITLE
Switch CLI output to streaming

### DIFF
--- a/devai/cli.py
+++ b/devai/cli.py
@@ -408,11 +408,17 @@ async def cli_main(
                     status = "ativada" if new_val else "desativada"
                     print(f"Execução isolada {status}")
                 else:
-                    async with ui.loading("Gerando resposta..."):
-                        response = await ai.generate_response(
-                            user_input, double_check=ai.double_check
-                        )
                     print("\nResposta:")
+                    tokens: list[str] = []
+                    async with ui.loading("Gerando resposta..."):
+                        async for token in ai.generate_response_stream(user_input):
+                            tokens.append(token)
+                            if plain:
+                                print(token, end="", flush=True)
+                            else:
+                                ui.console.print(token, end="")
+                    response = "".join(tokens)
+                    print()
                     is_patch = bool(
                         re.search(r"\ndiff --git", response)
                         or re.search(r"^[+-](?![+-])", response, re.MULTILINE)


### PR DESCRIPTION
## Summary
- stream responses in CLI and TUI via `generate_response_stream`
- show tokens as they arrive using `console.print`/`TextLog.write`
- add CLI streaming test

## Testing
- `pytest -q tests/test_cli.py::test_cli_exit tests/test_cli.py::test_cli_preferencia tests/test_cli.py::test_cli_tests_local tests/test_cli.py::test_cli_plain_mode tests/test_cli.py::test_cli_render_diff tests/test_cli.py::test_cli_render_diff_plusminus tests/test_cli.py::test_cli_stream_output tests/test_cli.py::test_cli_deletar_confirm tests/test_cli.py::test_cli_historia tests/test_cli.py::test_cliui_log_persistence tests/test_cli.py::test_cli_no_log -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dcd28fe483209345bbe7a51b22d2