### PR TITLE
Add side-by-side diff rendering

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,24 +58,42 @@ except Exception:  # pragma: no cover - fallback for test env
 
     syntax_mod = types.ModuleType('rich.syntax')
     class Syntax(str):
-        def __init__(self, code: str, *_a, **_k):
-            str.__init__(self)
+        def __new__(cls, code: str, *_a, **_k):
+            return str.__new__(cls, code)
     syntax_mod.Syntax = Syntax
 
     text_mod = types.ModuleType('rich.text')
-    text_mod.Text = str
+    class Text(str):
+        def __new__(cls, text: str = "", *_, style=None, **__):
+            return str.__new__(cls, text)
+    text_mod.Text = Text
+
+    table_mod = types.ModuleType('rich.table')
+    class Table:
+        def __init__(self, *a, **k):
+            pass
+        @classmethod
+        def grid(cls, *a, **k):
+            return cls()
+        def add_column(self, *a, **k):
+            pass
+        def add_row(self, *a, **k):
+            pass
+    table_mod.Table = Table
 
     rich_mod = types.ModuleType('rich')
     rich_mod.console = console_mod
     rich_mod.panel = panel_mod
     rich_mod.syntax = syntax_mod
     rich_mod.text = text_mod
+    rich_mod.table = table_mod
 
     sys.modules.setdefault('rich', rich_mod)
     sys.modules.setdefault('rich.console', console_mod)
     sys.modules.setdefault('rich.panel', panel_mod)
     sys.modules.setdefault('rich.syntax', syntax_mod)
     sys.modules.setdefault('rich.text', text_mod)
+    sys.modules.setdefault('rich.table', table_mod)
 
 try:
     from fastapi import FastAPI  # type: ignore  # noqa: F401

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,6 +165,28 @@ def test_cli_render_diff():
     assert any("..." in c for c in captured)
 
 
+def test_cli_render_diff_side_by_side():
+    from devai.ui import CLIUI
+    from rich.table import Table
+
+    ui = CLIUI()
+    captured: list[object] = []
+    panel = types.SimpleNamespace(clear=lambda: None, write=lambda t: captured.append(t))
+    ui.diff_panel = panel
+
+    diff_lines = [
+        "--- a/x",
+        "+++ b/x",
+        "@@",
+        "-old",
+        "+new",
+    ]
+    ui.render_diff("\n".join(diff_lines), side_by_side=True)
+
+    assert captured
+    assert isinstance(captured[0], Table)
+
+
 def test_cli_render_diff_plusminus(monkeypatch):
     class DiffAI(DummyAI):
         async def generate_response(self, q, **kw):


### PR DESCRIPTION
## Summary
- render diffs using Rich table when side_by_side=True
- stub Rich `Table` and update `Text` and `Syntax` in tests
- test new CLIUI side-by-side diff mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e0167c6c8320b90d67ae82c93bdf