### PR TITLE
Add basic TUI tests

### DIFF
--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,56 @@
+import pytest
+
+# skip if textual isn't installed
+textual = pytest.importorskip("textual")
+
+from devai.tui import TUIApp
+from devai.ui import CLIUI
+
+
+class DummyAI:
+    def __init__(self, stream=None):
+        self.stream = stream or []
+
+    async def generate_response_stream(self, _q):
+        for token in self.stream:
+            yield token
+
+
+@pytest.mark.asyncio
+async def test_tui_exit():
+    cli = CLIUI(log=False)
+    app = TUIApp(ai=DummyAI([]), cli_ui=cli, log=False)
+    async with app.run_test():
+        app.input.value = "/sair"
+        await app.action_submit()
+    assert cli.history[-1] == ">>> /sair"
+
+
+@pytest.mark.asyncio
+async def test_tui_streaming(monkeypatch):
+    cli = CLIUI(log=False)
+    captured: list[str] = []
+    ai = DummyAI(["a", "b", "c"])
+    app = TUIApp(ai=ai, cli_ui=cli, log=False)
+    async with app.run_test():
+        app.history_panel.write = lambda msg, scroll_end=False: captured.append(str(msg))
+        app.input.value = "hi"
+        await app.action_submit()
+    assert "a" in "".join(captured)
+    assert "b" in "".join(captured)
+    assert "c" in "".join(captured)
+
+
+@pytest.mark.asyncio
+async def test_tui_render_diff(monkeypatch):
+    diff_text = "\n".join(["--- a/x", "+++ b/x", "@@", "-old", "+new"]) + "\n"
+    cli = CLIUI(log=False)
+    diff_captured: list[str] = []
+    ai = DummyAI(list(diff_text))
+    app = TUIApp(ai=ai, cli_ui=cli, log=False)
+    async with app.run_test():
+        app.diff_panel.write = lambda msg: diff_captured.append(str(msg))
+        app.input.value = "show"
+        await app.action_submit()
+    assert diff_captured
+


### PR DESCRIPTION
## Summary
- add `tests/test_tui.py` exercising `TUIApp`
- ensure we can submit commands, stream output, and render diffs via `App.run_test`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e27164748320b6c861de852c9ea6