### PR TITLE
Enable side‑by‑side diff in TUI

### DIFF
--- a/devai/tui.py
+++ b/devai/tui.py
@@ -43,7 +43,7 @@ class TUIApp(App):
         self.progress_panel = TextLog(highlight=False, name="progress", height=3)
         self.input = Input(placeholder="Digite um comando...", name="input")
         left = Vertical(self.history_panel, self.progress_panel, self.input)
-        self.diff_panel = TextLog(highlight=True, name="diff")
+        self.diff_panel = TextLog(highlight=True, name="diff", wrap=False)
         self.cli.diff_panel = self.diff_panel
         self.cli.progress_handler = self._progress_update
         yield Horizontal(left, self.diff_panel)
@@ -94,7 +94,7 @@ class TUIApp(App):
             or re.search(r"^[+-](?![+-])", response, re.MULTILINE)
         )
         if is_patch:
-            self.cli.render_diff(response)
+            self.cli.render_diff(response, side_by_side=True, scroll=False)
         else:
             self.diff_panel.clear()
 

--- a/devai/ui.py
+++ b/devai/ui.py
@@ -77,7 +77,14 @@ class CLIUI:
             except Exception:
                 pass
 
-    def render_diff(self, diff: str, *, side_by_side: bool = False) -> None:
+    def render_diff(
+        self,
+        diff: str,
+        *,
+        side_by_side: bool = False,
+        collapse: bool = True,
+        scroll: bool = True,
+    ) -> None:
         if self.plain:
             print(diff)
             return
@@ -103,7 +110,7 @@ class CLIUI:
                 result.append("...")
             return "\n".join(result)
 
-        collapsed = _collapse(diff)
+        collapsed = _collapse(diff) if collapse else diff
 
         if side_by_side:
             lines = collapsed.splitlines()
@@ -129,7 +136,7 @@ class CLIUI:
         if self.diff_panel is not None:
             try:
                 self.diff_panel.clear()
-                self.diff_panel.write(renderable)
+                self.diff_panel.write(renderable, scroll_end=scroll)
             except Exception:
                 pass
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,14 @@ class DummyUI:
     def show_history(self) -> None:
         pass
 
-    def render_diff(self, diff: str) -> None:
+    def render_diff(
+        self,
+        diff: str,
+        *,
+        side_by_side: bool = False,
+        collapse: bool = True,
+        scroll: bool = True,
+    ) -> None:
         self.outputs.append(diff)
 
     def load_history(self, lines: int = 20) -> None:
@@ -146,7 +153,7 @@ def test_cli_render_diff():
     ui = CLIUI()
     captured: list[str] = []
     panel = types.SimpleNamespace(
-        clear=lambda: None, write=lambda t: captured.append(t)
+        clear=lambda: None, write=lambda t, scroll_end=True: captured.append(t)
     )
     ui.diff_panel = panel
 
@@ -171,7 +178,7 @@ def test_cli_render_diff_side_by_side():
 
     ui = CLIUI()
     captured: list[object] = []
-    panel = types.SimpleNamespace(clear=lambda: None, write=lambda t: captured.append(t))
+    panel = types.SimpleNamespace(clear=lambda: None, write=lambda t, scroll_end=True: captured.append(t))
     ui.diff_panel = panel
 
     diff_lines = [

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -45,12 +45,28 @@ async def test_tui_streaming(monkeypatch):
 async def test_tui_render_diff(monkeypatch):
     diff_text = "\n".join(["--- a/x", "+++ b/x", "@@", "-old", "+new"]) + "\n"
     cli = CLIUI(log=False)
-    diff_captured: list[str] = []
+    diff_captured: list[object] = []
     ai = DummyAI(list(diff_text))
     app = TUIApp(ai=ai, cli_ui=cli, log=False)
     async with app.run_test():
-        app.diff_panel.write = lambda msg: diff_captured.append(str(msg))
+        app.diff_panel.write = lambda msg, scroll_end=True: diff_captured.append(msg)
         app.input.value = "show"
         await app.action_submit()
     assert diff_captured
+
+
+@pytest.mark.asyncio
+async def test_tui_render_diff_side_by_side(monkeypatch):
+    diff_text = "\n".join(["--- a/x", "+++ b/x", "@@", "-old", "+new"]) + "\n"
+    cli = CLIUI(log=False)
+    diff_captured: list[object] = []
+    ai = DummyAI(list(diff_text))
+    app = TUIApp(ai=ai, cli_ui=cli, log=False)
+    async with app.run_test():
+        app.diff_panel.write = lambda msg, scroll_end=True: diff_captured.append(msg)
+        app.input.value = "show"
+        await app.action_submit()
+    from rich.table import Table
+    assert diff_captured
+    assert isinstance(diff_captured[0], Table)
 


### PR DESCRIPTION
## Summary
- support collapsing and scrolling diff output
- show side-by-side diff in TUI using `rich.table.Table`
- update CLIUI API
- extend tests for new diff mode

## Testing
- `pytest tests/test_cli.py tests/test_tui.py -k "test_cli_render_diff or test_cli_render_diff_side_by_side or test_tui_render_diff" -vv`

------
https://chatgpt.com/codex/tasks/task_e_6846e6f4a7a48320b57c952715e71fc7