### PR TITLE
Improve CLI path completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Por padrão a CLI utiliza a interface colorida do [Rich](https://github.com/Text
 
 Atalhos comuns:
 - setas **↑/↓** percorrem o histórico de comandos;
-- **Tab** autocompleta nomes e caminhos.
+- **Tab** sugere comandos e caminhos de arquivo.
 
 Exemplo de tela:
 
@@ -110,7 +110,7 @@ python -m devai --cli --tui
 A TUI exibe janelas de histórico e diff. Os mesmos atalhos funcionam:
 
 - setas **↑/↓** percorrem o histórico de comandos;
-- **Tab** autocompleta nomes e caminhos.
+- **Tab** sugere comandos e caminhos de arquivo.
 
 ### Gerenciamento de arquivos
 


### PR DESCRIPTION
## Summary
- combine `WordCompleter` with `PathCompleter` for better CLI completion
- note path completion enhancement in `README`
- test that `PathCompleter` is present when `prompt_toolkit` is available

## Testing
- `pytest tests/test_cli.py::test_cliui_includes_path_completer -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684703071a008320a4af040b60ce2b0d