### PR TITLE
Implement approval levels and logging

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -87,6 +87,6 @@ devai ajuda
 
 Defina `APPROVAL_MODE` em `config.yaml` ou via `--approval-mode`:
 
-- `auto` aplica tudo automaticamente;
-- `suggest` solicita confirmação para patches e comandos externos;
-- `manual` pergunta antes de qualquer ação.
+- `full_auto` aplica tudo automaticamente;
+- `auto_edit` confirma apenas comandos de shell;
+- `suggest` confirma alterações de código e comandos externos.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ TEST_MEMORY_LIMIT_MB: 512
 O parâmetro `APPROVAL_MODE` define quando o DevAI solicita confirmação antes de
 executar ações sensíveis. Valores possíveis:
 
-- `auto` – nenhuma confirmação é pedida;
-- `suggest` – confirma alterações de código e comandos externos;
-- `manual` – sempre pergunta antes de qualquer operação.
+- `full_auto` – nenhuma confirmação é pedida;
+- `auto_edit` – confirma apenas comandos de shell;
+- `suggest` – confirma alterações de código e comandos externos.
 
 Você pode ajustar no `config.yaml` ou via `--approval-mode` ao iniciar.
 

--- a/devai/approval.py
+++ b/devai/approval.py
@@ -1,12 +1,13 @@
 from .config import config
 
-_actions_suggest = {"patch", "shell", "edit", "delete", "create"}
+WRITE_ACTIONS = {"patch", "edit", "create", "delete"}
+
 
 def requires_approval(action: str) -> bool:
     """Return True if the given action requires confirmation."""
-    mode = getattr(config, "APPROVAL_MODE", "suggest")
-    if mode == "manual":
-        return True
-    if mode == "auto":
+    mode = getattr(config, "APPROVAL_MODE", "suggest").lower()
+    if mode == "full_auto":
         return False
-    return action in _actions_suggest
+    if mode == "auto_edit":
+        return action == "shell"
+    return action in WRITE_ACTIONS or action == "shell"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,7 +73,7 @@ APPROVAL_MODE: suggest
 
 Valores aceitos:
 
-- `auto` – nenhuma confirmação de operações;
-- `suggest` – confirma ações como aplicação de patches ou execução de shell;
-- `manual` – solicita confirmação para qualquer alteração.
+- `full_auto` – nenhuma confirmação de operações;
+- `auto_edit` – confirma somente comandos de shell;
+- `suggest` – confirma ações de escrita ou execução de shell.
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -12,11 +12,13 @@ def _write_cfg(tmp_path, text):
 
 
 def test_config_approval(tmp_path, monkeypatch):
-    path = _write_cfg(tmp_path, "APPROVAL_MODE: manual\n")
-    fake_yaml = types.SimpleNamespace(safe_load=lambda f: {"APPROVAL_MODE": "manual"})
+    path = _write_cfg(tmp_path, "APPROVAL_MODE: auto_edit\n")
+    fake_yaml = types.SimpleNamespace(
+        safe_load=lambda f: {"APPROVAL_MODE": "auto_edit"}
+    )
     monkeypatch.setattr(config_utils, "yaml", fake_yaml)
     cfg = Config(path)
-    assert cfg.APPROVAL_MODE == "manual"
+    assert cfg.APPROVAL_MODE == "auto_edit"
 
 
 def test_config_invalid_approval(tmp_path, monkeypatch):
@@ -28,10 +30,12 @@ def test_config_invalid_approval(tmp_path, monkeypatch):
 
 
 def test_requires_approval(monkeypatch):
-    monkeypatch.setattr(config, "APPROVAL_MODE", "auto")
+    monkeypatch.setattr(config, "APPROVAL_MODE", "full_auto")
     assert not requires_approval("patch")
-    monkeypatch.setattr(config, "APPROVAL_MODE", "manual")
-    assert requires_approval("anything")
+    monkeypatch.setattr(config, "APPROVAL_MODE", "auto_edit")
+    assert requires_approval("shell")
+    assert not requires_approval("patch")
     monkeypatch.setattr(config, "APPROVAL_MODE", "suggest")
     assert requires_approval("patch")
+    assert requires_approval("shell")
     assert not requires_approval("other")


### PR DESCRIPTION
## Summary
- expand config validation to support `suggest`, `auto_edit` and `full_auto`
- add new approval logic and logging for actions
- expose approval mode via CLI
- document the new modes
- update tests for revised behaviour

## Testing
- `black devai/config.py devai/__main__.py devai/approval.py devai/tasks.py devai/command_router.py tests/test_approval.py`
- `pytest -q` *(fails: PytestUnhandledCoroutineWarning)*

------
https://chatgpt.com/codex/tasks/task_e_68471b6113348320afba829dfb76d61e