### PR TITLE
Add approval mode command

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -75,6 +75,14 @@ Exemplo:
 devai historico_cli 50
 ```
 
+## /modo <suggest|auto_edit|full_auto>
+Define rapidamente o `APPROVAL_MODE` sem editar arquivos.
+
+Exemplo:
+```bash
+devai modo auto_edit
+```
+
 ## /ajuda
 Mostra esta referência de comandos diretamente na CLI.
 
@@ -90,3 +98,4 @@ Defina `APPROVAL_MODE` em `config.yaml` ou via `--approval-mode`:
 - `full_auto` aplica tudo automaticamente;
 - `auto_edit` confirma apenas comandos de shell;
 - `suggest` confirma alterações de código e comandos externos.
+Também é possível alternar dinâmicamente usando `/modo`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ executar ações sensíveis. Valores possíveis:
 - `auto_edit` – confirma apenas comandos de shell;
 - `suggest` – confirma alterações de código e comandos externos.
 
-Você pode ajustar no `config.yaml` ou via `--approval-mode` ao iniciar.
+Você pode ajustar no `config.yaml`, via `--approval-mode` ao iniciar
+ou dinamicamente com o comando `/modo`.
 
 O DevAI traz versões simplificadas de algumas bibliotecas (como `aiohttp` e `fastapi`) usadas apenas em testes offline. O módulo `dependency_check` avisará caso essas versões estejam ativas, recomendando a instalação dos pacotes reais.
 
@@ -135,7 +136,8 @@ Além das tarefas padrão, a CLI permite explorar e modificar o diretório defin
 - `/deletar <caminho>` remove arquivo ou diretório (requer confirmação).
 - `/tarefa auto_refactor <arquivo>` refatora o arquivo informado e executa os testes.
 - `/historia [sessao]` exibe o histórico de conversa da sessão indicada.
-- `/historico_cli [N]` mostra N últimas linhas do log da CLI (ou todo o arquivo).
+- `/historico_cli [N]` mostra N últimas linhas do log da CLI (ou todo o arquivo). 
+- `/modo <suggest|auto_edit|full_auto>` altera o nível de aprovação em tempo real.
 - `/ajuda` exibe a documentação completa de comandos.
 
 Ao usar `/deletar`, a CLI exibe um diálogo de confirmação para evitar remoções acidentais.

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -83,6 +83,7 @@ async def cli_main(
     print("/historia [sessao] - Exibe histórico de conversa")
     print("/historico <arquivo> - Mostra histórico de mudanças")
     print("/historico_cli [N] - Exibe N linhas do log da CLI (ou tudo)")
+    print("/modo <suggest|auto_edit|full_auto> - Altera modo de aprovação")
     print("/ajuda - Mostra documentação dos comandos")
     print("/feedback <arquivo> <tag> <motivo> - Registrar feedback negativo")
     print("/refatorar <arquivo> - Refatora o arquivo informado")

--- a/devai/command_router.py
+++ b/devai/command_router.py
@@ -408,6 +408,18 @@ async def handle_tests_local(ai, ui, args, *, plain, feedback_db):
     print(f"Execução isolada {status}")
 
 
+async def handle_modo(ai, ui, args, *, plain, feedback_db):
+    """Alterar config.APPROVAL_MODE em tempo real."""
+    mode = args.strip().lower()
+    if mode not in {"suggest", "auto_edit", "full_auto"}:
+        print("Uso: /modo <suggest|auto_edit|full_auto>")
+        return
+    old = config.APPROVAL_MODE
+    config.APPROVAL_MODE = mode
+    logger.info("Modo de aprovação alterado", antigo=old, novo=mode)
+    log_decision("config", "APPROVAL_MODE", f"{old}->{mode}", "cli", "ok")
+
+
 def _split_diff_by_file(diff: str) -> Dict[str, str]:
     """Return a mapping of file path to its diff chunk."""
     files: Dict[str, list[str]] = {}
@@ -545,6 +557,7 @@ COMMANDS = {
     "feedback": handle_feedback,
     "refatorar": handle_refatorar,
     "rever": handle_rever,
+    "modo": handle_modo,
     "resetar": handle_resetar,
     "tests_local": handle_tests_local,
 }


### PR DESCRIPTION
## Summary
- allow switching approval modes on the fly with `/modo`
- mention the new command in CLI help
- document `/modo` in `COMMANDS_REFERENCE.md` and `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471f6d4ad08320a9129a8fdfa40169