### PR TITLE
Implement remembered approvals

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -37,6 +37,9 @@ devai ajustar estilo:modo_refatoracao valor:seguro
 ## /rastrear <arquivo|tarefa>
 Exibe o histórico simbólico de decisões e modificações que afetaram o alvo informado.
 
+## /decisoes [lembrar|esquecer <id>]
+Lista decisões registradas e permite marcar ou desmarcar a opção de lembrar aprovações.
+
 ## /memoria tipo:<tag> [filtro:<texto>]
 Busca memórias armazenadas filtrando por tipo e texto. Possui paginação e a flag `--detalhado` para mostrar informações completas.
 

--- a/devai/approval.py
+++ b/devai/approval.py
@@ -1,10 +1,14 @@
 from .config import config
+from .decision_log import is_remembered
 
 WRITE_ACTIONS = {"patch", "edit", "create", "delete"}
 
 
-def requires_approval(action: str) -> bool:
+def requires_approval(action: str, path: str | None = None) -> bool:
     """Return True if the given action requires confirmation."""
+    if path and is_remembered(action, path):
+        return False
+
     mode = getattr(config, "APPROVAL_MODE", "suggest").lower()
     if mode == "full_auto":
         return False

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -70,6 +70,7 @@ async def cli_main(
     print("/esquecer <termo> - Desativa memórias")
     print("/ajustar estilo:<param> valor:<opcao> - Ajusta preferência")
     print("/rastrear <arquivo|tarefa> - Mostra histórico")
+    print("/decisoes [lembrar|esquecer <id>] - Gerencia aprovações lembradas")
     print("/tarefa <nome> [args] - Executa uma tarefa")
     print("/analisar <função> - Analisa impacto de mudanças")
     print("/verificar - Verifica conformidade com especificação")


### PR DESCRIPTION
## Summary
- add `remember` flag and lookup to decision log
- check remembered decisions in `requires_approval`
- prompt for remembering in CLI confirmations
- manage remembered approvals with `/decisoes`
- update docs and tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684720ca82e0832095fa99c61cc2286b