### PR TITLE
Implement web approval workflow

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -6,5 +6,7 @@ Endpoints principais para integração e painel IDE:
 - `GET /file` – obtém conteúdo de um arquivo.
 - `GET /actions` – retorna histórico de decisões do DevAI.
 - `GET /diff?file=<nome>` – mostra diferença da última alteração registrada.
+- `GET /approval_request` – aguarda até que o servidor solicite uma confirmação e retorna `{ "message": "texto" }`.
+- `POST /approval_request` – envia `{ "approved": true|false }` para responder à solicitação pendente.
 
 Estes endpoints permitem integração futura com VSCode ou JetBrains.

--- a/devai/approval.py
+++ b/devai/approval.py
@@ -1,5 +1,10 @@
 from .config import config
 from .decision_log import is_remembered
+import asyncio
+
+_approval_event = asyncio.Event()
+_approval_future: asyncio.Future | None = None
+_approval_message = ""
 
 WRITE_ACTIONS = {"patch", "edit", "create", "delete"}
 
@@ -15,3 +20,30 @@ def requires_approval(action: str, path: str | None = None) -> bool:
     if mode == "auto_edit":
         return action == "shell"
     return action in WRITE_ACTIONS or action == "shell"
+
+
+async def request_approval(message: str) -> bool:
+    """Trigger approval flow in web mode and wait for result."""
+    global _approval_future, _approval_message
+    if _approval_future is not None:
+        raise RuntimeError("Another approval in progress")
+    _approval_future = asyncio.get_running_loop().create_future()
+    _approval_message = message
+    _approval_event.set()
+    result = await _approval_future
+    _approval_future = None
+    return bool(result)
+
+
+async def wait_for_request() -> dict:
+    """Wait until a request is available for the frontend."""
+    await _approval_event.wait()
+    _approval_event.clear()
+    return {"message": _approval_message}
+
+
+def resolve_request(approved: bool) -> None:
+    """Resolve the current pending approval request."""
+    global _approval_future
+    if _approval_future and not _approval_future.done():
+        _approval_future.set_result(bool(approved))

--- a/static/style.css
+++ b/static/style.css
@@ -130,3 +130,19 @@
   overflow: auto;
   margin-top: 10px;
 }
+
+.modal{
+  position:fixed;
+  top:0;left:0;right:0;bottom:0;
+  background:rgba(0,0,0,0.5);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:2000;
+}
+.modal-content{
+  background:#fff;
+  padding:20px;
+  border-radius:4px;
+}
+.modal-content button{margin:0 5px;}


### PR DESCRIPTION
## Summary
- add async request handling for approvals
- create `/approval_request` API endpoints
- prompt web users for approvals via modal dialog
- trigger web flow when approval needed
- document approval_request API usage

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(interrupted due to missing async plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6847261f39b88320ad92f11718d3d3f6