### PR TITLE
Add token-based approval notifications

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -6,7 +6,11 @@ Endpoints principais para integração e painel IDE:
 - `GET /file` – obtém conteúdo de um arquivo.
 - `GET /actions` – retorna histórico de decisões do DevAI.
 - `GET /diff?file=<nome>` – mostra diferença da última alteração registrada.
-- `GET /approval_request` – aguarda até que o servidor solicite uma confirmação e retorna `{ "message": "texto" }`.
-- `POST /approval_request` – envia `{ "approved": true|false }` para responder à solicitação pendente.
+- `GET /approval_request` – aguarda até que o servidor solicite uma confirmação e retorna `{ "message": "texto", "token": "id" }`.
+- `POST /approval_request` – envia `{ "approved": true|false, "token": "id" }` para responder à solicitação pendente.
+
+Se `NOTIFY_EMAIL` ou `NOTIFY_SLACK` estiverem configurados, cada pedido de aprovação gera um e-mail ou mensagem com links diretos:
+`http://localhost:<porta>/approval_request?token=<id>&approved=true` ou `...&approved=false`.
+Ao clicar, o endpoint `POST /approval_request` é acionado e a decisão é registrada.
 
 Estes endpoints permitem integração futura com VSCode ou JetBrains.

--- a/devai/approval.py
+++ b/devai/approval.py
@@ -2,10 +2,13 @@ from .config import config
 from .decision_log import is_remembered
 import asyncio
 from pathlib import Path
+from uuid import uuid4
+from .notifier import Notifier
 
 _approval_event = asyncio.Event()
 _approval_future: asyncio.Future | None = None
 _approval_message = ""
+_approval_token = ""
 
 # Remaining actions allowed without manual approval
 auto_approve_remaining = 0
@@ -49,11 +52,21 @@ def requires_approval(action: str, path: str | None = None) -> bool:
 
 async def request_approval(message: str) -> bool:
     """Trigger approval flow in web mode and wait for result."""
-    global _approval_future, _approval_message
+    global _approval_future, _approval_message, _approval_token
     if _approval_future is not None:
         raise RuntimeError("Another approval in progress")
     _approval_future = asyncio.get_running_loop().create_future()
     _approval_message = message
+    _approval_token = uuid4().hex
+    notifier = Notifier()
+    if notifier.enabled:
+        base_url = f"http://localhost:{config.API_PORT}"
+        approve = f"{base_url}/approval_request?token={_approval_token}&approved=true"
+        reject = f"{base_url}/approval_request?token={_approval_token}&approved=false"
+        notifier.send(
+            "Confirmação necessária",
+            f"{message}\nAprovar: {approve}\nRejeitar: {reject}",
+        )
     _approval_event.set()
     result = await _approval_future
     _approval_future = None
@@ -64,11 +77,17 @@ async def wait_for_request() -> dict:
     """Wait until a request is available for the frontend."""
     await _approval_event.wait()
     _approval_event.clear()
-    return {"message": _approval_message}
+    return {"message": _approval_message, "token": _approval_token}
 
 
 def resolve_request(approved: bool) -> None:
     """Resolve the current pending approval request."""
-    global _approval_future
+    global _approval_future, _approval_token
     if _approval_future and not _approval_future.done():
         _approval_future.set_result(bool(approved))
+    _approval_token = ""
+
+
+def verify_token(token: str) -> bool:
+    """Return True if token matches the current approval token."""
+    return bool(token) and token == _approval_token

--- a/devai/core.py
+++ b/devai/core.py
@@ -722,14 +722,16 @@ class CodeMemoryAI:
             summary = await self.learning_engine.explain_learning_lessons()
             return {"summary": summary}
 
-        from .approval import wait_for_request, resolve_request
+        from .approval import wait_for_request, resolve_request, verify_token
 
         @self.app.get("/approval_request")
         async def approval_wait():
             return await wait_for_request()
 
         @self.app.post("/approval_request")
-        async def approval_answer(approved: bool):
+        async def approval_answer(approved: bool, token: str):
+            if not verify_token(token):
+                return {"status": "invalid"}
             resolve_request(approved)
             return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- notify via Slack/email when requesting approval
- include approval token in notification and API response
- verify token on approval answer
- document setup in API guide
- test approval notifier with token

## Testing
- `pytest tests/test_approval.py -q`
- `pytest tests/test_approval.py::test_request_approval_notifies -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684735fa7cec83209b4b4b6637c9c751