### PR TITLE
Implement /regras command and config reload

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -95,6 +95,17 @@ Exemplo:
 devai aprovar_proxima 3
 ```
 
+## /regras [add <acao> <caminho> <sim|nao>|del <id>]
+Gerencia as `AUTO_APPROVAL_RULES` do `config.yaml`. Sem argumentos apenas lista
+as regras atuais numeradas.
+
+Exemplo:
+```bash
+devai regras
+devai regras add edit docs/** sim
+devai regras del 1
+```
+
 ## /ajuda
 Mostra esta referência de comandos diretamente na CLI.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ duas colunas.
 Você pode ajustar no `config.yaml`, via `--approval-mode` ao iniciar
 ou dinamicamente com o comando `/modo`.
 
+Para manipular regras específicas de autoaprovação utilize `/regras`. O comando
+permite listar, adicionar e remover entradas em `AUTO_APPROVAL_RULES` sem editar
+o arquivo manualmente.
+
 O DevAI traz versões simplificadas de algumas bibliotecas (como `aiohttp` e `fastapi`) usadas apenas em testes offline. O módulo `dependency_check` avisará caso essas versões estejam ativas, recomendando a instalação dos pacotes reais.
 
 ## Executando

--- a/devai/config.py
+++ b/devai/config.py
@@ -75,6 +75,9 @@ class Config:
     AUTO_APPROVAL_RULES: list[dict] = field(default_factory=list)
 
     def __init__(self, path: str = "config.yaml") -> None:
+        self._load(path)
+
+    def _load(self, path: str) -> None:
         defaults: Dict[str, Any] = {}
         for f in fields(self.__class__):
             if f.default is not MISSING:
@@ -94,6 +97,10 @@ class Config:
                     "Valores divergentes para 'MODEL_NAME' e 'MODELS.default.name'"
                 )
         self._validate()
+
+    def reload(self, path: str = "config.yaml") -> None:
+        """Reload configuration from ``path`` updating current fields."""
+        self._load(path)
 
     def _validate(self) -> None:
         if not isinstance(self.API_PORT, int):


### PR DESCRIPTION
## Summary
- add configuration reload capability
- implement `/regras` command for auto-approval rules
- document new command in help and README
- expose `/regras` in command mapping

## Testing
- `pre-commit run --files devai/command_router.py devai/config.py COMMANDS_REFERENCE.md README.md`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68473a0ec19083208d5cff7e994fa53f