### PR TITLE
Add rule suggestion utility and command

### DIFF
--- a/COMMANDS_REFERENCE.md
+++ b/COMMANDS_REFERENCE.md
@@ -106,6 +106,16 @@ devai regras add edit docs/** sim
 devai regras del 1
 ```
 
+## /sugerir_regras [N] [--salvar]
+Mostra sugestões de regras automáticas com base no `decision_log.yaml`.
+`N` define o mínimo de aprovações para gerar a dica (padrão `3`).
+Use `--salvar` para escrever as regras sugeridas no `config.yaml`.
+
+Exemplo:
+```bash
+devai sugerir_regras 5 --salvar
+```
+
 ## /ajuda
 Mostra esta referência de comandos diretamente na CLI.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,6 +93,9 @@ AUTO_APPROVAL_RULES:
 `path` usa sintaxe glob. Se `approve` for `true` a ação é aplicada
 sem perguntar; `false` exige confirmação mesmo em modos automáticos.
 
+O comando `/sugerir_regras` pode analisar o `decision_log.yaml` e
+propor entradas para esta lista automaticamente.
+
 ## Estilo de diff
 
 O DevAI pode mostrar patches lado a lado ou no formato tradicional. Defina

--- a/tests/test_suggest_rules.py
+++ b/tests/test_suggest_rules.py
@@ -1,0 +1,19 @@
+import json
+import types
+import devai.decision_log as dl
+
+
+def test_suggest_rules(monkeypatch, tmp_path):
+    log_file = tmp_path / "decision_log.yaml"
+    data = [
+        {"tipo": "edit", "modulo": "docs/a.txt", "hash_resultado": dl.OK_HASH},
+        {"tipo": "edit", "modulo": "docs/a.txt", "hash_resultado": dl.OK_HASH},
+        {"tipo": "edit", "modulo": "docs/a.txt", "hash_resultado": dl.OK_HASH},
+        {"tipo": "create", "modulo": "src/b.py", "hash_resultado": dl.OK_HASH},
+    ]
+    log_file.write_text(json.dumps(data))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(dl, "yaml", types.SimpleNamespace(safe_load=json.loads))
+    rules = dl.suggest_rules(3)
+    assert {"action": "edit", "path": "docs/a.txt", "approve": True} in rules
+    assert all(r["action"] != "create" for r in rules)


### PR DESCRIPTION
## Summary
- offer suggestions for AUTO_APPROVAL_RULES from decision_log
- implement `/sugerir_regras` command to show and optionally store them
- document the command
- mention rule suggestion in configuration guide
- test the new suggest_rules helper

## Testing
- `pre-commit run --files devai/decision_log.py devai/command_router.py COMMANDS_REFERENCE.md docs/CONFIGURATION.md tests/test_suggest_rules.py` *(fails: command not found)*
- `pytest tests/test_suggest_rules.py`

------
https://chatgpt.com/codex/tasks/task_e_68473bcd44b88320aa3c24b925500218