### PR TITLE
Add shell_safe action

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -185,6 +185,7 @@ def main():
                         file_path, lambda p: p.write_text(new_code), capture_output=True
                     )
                     if not success and rollback:
+                        # shell: rollback patch
                         subprocess.run(
                             ["git", "apply", "-R", patch_path], cwd=config.CODE_ROOT
                         )

--- a/devai/approval.py
+++ b/devai/approval.py
@@ -15,6 +15,9 @@ auto_approve_remaining = 0
 
 WRITE_ACTIONS = {"patch", "edit", "create", "delete"}
 
+# Commands that are read-only and safe to run automatically
+SAFE_ACTIONS = {"shell_safe"}
+
 
 def match_glob(pattern: str, target: str) -> bool:
     """Return True if ``target`` matches the glob ``pattern``."""
@@ -41,6 +44,10 @@ def requires_approval(action: str, path: str | None = None) -> bool:
                 return not rule.get("approve", False)
         except Exception:
             continue
+
+    # Actions explicitly marked as safe never require confirmation
+    if action in SAFE_ACTIONS:
+        return False
 
     mode = getattr(config, "APPROVAL_MODE", "suggest").lower()
     if mode == "full_auto":

--- a/devai/sandbox.py
+++ b/devai/sandbox.py
@@ -26,6 +26,7 @@ class Sandbox:
             self.image,
             *command,
         ]
+        # shell: docker run
         proc = subprocess.Popen(
             docker_cmd,
             stdout=subprocess.PIPE,

--- a/devai/shadow_mode.py
+++ b/devai/shadow_mode.py
@@ -42,6 +42,7 @@ def simulate_update(
     patch_file.write(diff.encode("utf-8"))
     patch_file.close()
 
+    # shell_safe: git apply --check only validates the patch
     proc = subprocess.run(
         ["git", "apply", "--check", patch_file.name],
         cwd=project_root,

--- a/devai/tasks.py
+++ b/devai/tasks.py
@@ -135,10 +135,10 @@ class TaskManager:
         logger.info("Executando tarefa", task=task_name)
         action_map = {
             "test": "shell",
-            "static_analysis": "shell",
-            "security_analysis": "shell",
-            "pylint": "shell",
-            "type_check": "shell",
+            "static_analysis": "shell_safe",
+            "security_analysis": "shell_safe",
+            "pylint": "shell_safe",
+            "type_check": "shell_safe",
             "coverage": "shell",
             "auto_refactor": "edit",
         }
@@ -398,7 +398,7 @@ class TaskManager:
     async def _perform_static_analysis_task(
         self, task: Dict, *args, ui=None
     ) -> List[str]:
-        if requires_approval("shell"):
+        if requires_approval("shell_safe"):
             if ui:
                 approved = await ui.confirm("Executar análise estática?")
                 model = "cli"
@@ -406,7 +406,7 @@ class TaskManager:
                 approved = await request_approval("Executar análise estática?")
                 model = "web"
             log_decision(
-                "shell",
+                "shell_safe",
                 task.get("type", "static"),
                 "execucao",
                 model,
@@ -435,7 +435,7 @@ class TaskManager:
     async def _perform_security_analysis_task(
         self, task: Dict, *args, ui=None
     ) -> List[str]:
-        if requires_approval("shell"):
+        if requires_approval("shell_safe"):
             if ui:
                 approved = await ui.confirm("Executar análise de segurança?")
                 model = "cli"
@@ -443,7 +443,7 @@ class TaskManager:
                 approved = await request_approval("Executar análise de segurança?")
                 model = "web"
             log_decision(
-                "shell",
+                "shell_safe",
                 task.get("type", "security"),
                 "execucao",
                 model,
@@ -470,7 +470,7 @@ class TaskManager:
             return [f"Erro na análise de segurança: {e}"]
 
     async def _perform_pylint_task(self, task: Dict, *args, ui=None) -> List[str]:
-        if requires_approval("shell"):
+        if requires_approval("shell_safe"):
             if ui:
                 approved = await ui.confirm("Executar pylint?")
                 model = "cli"
@@ -478,7 +478,7 @@ class TaskManager:
                 approved = await request_approval("Executar pylint?")
                 model = "web"
             log_decision(
-                "shell",
+                "shell_safe",
                 task.get("type", "pylint"),
                 "execucao",
                 model,
@@ -505,7 +505,7 @@ class TaskManager:
             return [f"Erro no pylint: {e}"]
 
     async def _perform_type_check_task(self, task: Dict, *args, ui=None) -> List[str]:
-        if requires_approval("shell"):
+        if requires_approval("shell_safe"):
             if ui:
                 approved = await ui.confirm("Executar verificação de tipos?")
                 model = "cli"
@@ -513,7 +513,7 @@ class TaskManager:
                 approved = await request_approval("Executar verificação de tipos?")
                 model = "web"
             log_decision(
-                "shell",
+                "shell_safe",
                 task.get("type", "type_check"),
                 "execucao",
                 model,

--- a/devai/test_runner.py
+++ b/devai/test_runner.py
@@ -76,6 +76,7 @@ def run_pytest(path: str | Path, timeout: int = 30) -> Tuple[bool, str]:
         preexec = _limits if resource is not None else None
 
         try:
+            # shell: run pytest
             proc = subprocess.run(
                 ["pytest", "-q"],
                 stdout=subprocess.PIPE,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,6 +77,9 @@ Valores aceitos:
 - `auto_edit` – confirma somente comandos de shell;
 - `suggest` – confirma ações de escrita ou execução de shell.
 
+Comandos classificados como `shell_safe` são aprovados automaticamente,
+mesmo no modo `suggest`.
+
 ### Regras de autoaprovação
 
 O campo `AUTO_APPROVAL_RULES` permite ignorar ou forçar confirmações

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -36,12 +36,15 @@ def test_config_invalid_approval(tmp_path, monkeypatch):
 def test_requires_approval(monkeypatch):
     monkeypatch.setattr(config, "APPROVAL_MODE", "full_auto")
     assert not requires_approval("patch")
+    assert not requires_approval("shell_safe")
     monkeypatch.setattr(config, "APPROVAL_MODE", "auto_edit")
     assert requires_approval("shell")
     assert not requires_approval("patch")
+    assert not requires_approval("shell_safe")
     monkeypatch.setattr(config, "APPROVAL_MODE", "suggest")
     assert requires_approval("patch")
     assert requires_approval("shell")
+    assert not requires_approval("shell_safe")
     assert not requires_approval("other")
 
 
@@ -90,6 +93,17 @@ def test_auto_approval_rules_force(monkeypatch):
     monkeypatch.setattr(config, "APPROVAL_MODE", "full_auto")
     assert requires_approval("edit", "docs/file.md")
     assert not requires_approval("edit", "src/file.py")
+
+
+def test_auto_approval_shell_safe(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "AUTO_APPROVAL_RULES",
+        [{"action": "shell_safe", "path": "scripts/**", "approve": False}],
+    )
+    monkeypatch.setattr(config, "APPROVAL_MODE", "suggest")
+    assert requires_approval("shell_safe", "scripts/run.sh")
+    assert not requires_approval("shell_safe", "other/run.sh")
 
 
 def test_temporary_auto_approval(monkeypatch):


### PR DESCRIPTION
## Summary
- add `shell_safe` action to approval logic
- treat static analysis subprocesses as `shell_safe`
- mark subprocess calls with comments
- auto-approve `shell_safe` actions in approval checks
- document new action type
- test the new behaviour

## Testing
- `pytest tests/test_approval.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68473d96aec48320a6160a4665e0d33d