### PR TITLE
Add shell_safe action type and tagging

### DIFF
--- a/devai/approval.py
+++ b/devai/approval.py
@@ -15,6 +15,9 @@ auto_approve_remaining = 0
 
 WRITE_ACTIONS = {"patch", "edit", "create", "delete"}
 
+# Shell execution categories
+SHELL_ACTIONS = {"shell", "shell_safe"}
+
 # Commands that are read-only and safe to run automatically
 SAFE_ACTIONS = {"shell_safe"}
 
@@ -54,7 +57,7 @@ def requires_approval(action: str, path: str | None = None) -> bool:
         return False
     if mode == "auto_edit":
         return action == "shell"
-    return action in WRITE_ACTIONS or action == "shell"
+    return action in WRITE_ACTIONS or action in SHELL_ACTIONS
 
 
 async def request_approval(message: str) -> bool:

--- a/devai/tasks.py
+++ b/devai/tasks.py
@@ -416,6 +416,7 @@ class TaskManager:
                 return ["cancelado"]
         cmd = ["flake8", str(self.code_analyzer.code_root)]
         try:
+            # shell_safe: run flake8
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
@@ -453,6 +454,7 @@ class TaskManager:
                 return ["cancelado"]
         cmd = ["bandit", "-r", str(self.code_analyzer.code_root)]
         try:
+            # shell_safe: run bandit
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
@@ -488,6 +490,7 @@ class TaskManager:
                 return ["cancelado"]
         cmd = ["pylint", str(self.code_analyzer.code_root)]
         try:
+            # shell_safe: run pylint
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
@@ -523,6 +526,7 @@ class TaskManager:
                 return ["cancelado"]
         cmd = ["mypy", str(self.code_analyzer.code_root)]
         try:
+            # shell_safe: run mypy
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
@@ -562,6 +566,7 @@ class TaskManager:
         try:
             if progress_cb:
                 progress_cb(0, "running tests")
+            # shell: run coverage
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdout=asyncio.subprocess.PIPE,
@@ -570,6 +575,7 @@ class TaskManager:
             out, _ = await proc.communicate()
             if progress_cb:
                 progress_cb(70, "analyzing coverage")
+            # shell: coverage report
             report_proc = await asyncio.create_subprocess_exec(
                 "coverage",
                 "report",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -78,7 +78,9 @@ Valores aceitos:
 - `suggest` – confirma ações de escrita ou execução de shell.
 
 Comandos classificados como `shell_safe` são aprovados automaticamente,
-mesmo no modo `suggest`.
+mesmo no modo `suggest`. Use essa categoria para operações de leitura, como
+`ls` ou `cat`. Demais execuções devem ser marcadas como `shell` e exigem
+confirmação dependendo do modo configurado.
 
 ### Regras de autoaprovação
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -106,6 +106,12 @@ def test_auto_approval_shell_safe(monkeypatch):
     assert not requires_approval("shell_safe", "other/run.sh")
 
 
+def test_shell_safe_constants():
+    assert "shell_safe" in approval.SAFE_ACTIONS
+    assert "shell" in approval.SHELL_ACTIONS
+    assert "shell_safe" in approval.SHELL_ACTIONS
+
+
 def test_temporary_auto_approval(monkeypatch):
     monkeypatch.setattr(config, "APPROVAL_MODE", "suggest")
     command_router.approval.auto_approve_remaining = 0


### PR DESCRIPTION
## Summary
- extend `devai/approval` with `SHELL_ACTIONS`
- annotate subprocess calls with `shell` or `shell_safe`
- document difference between `shell` and `shell_safe`
- add test for new constants

## Testing
- `pytest tests/test_approval.py::test_shell_safe_constants -q`
- `pytest tests/test_approval.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68481b4d605483208f805ba20483df49