### PR TITLE
Add approval details support

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -6,7 +6,7 @@ Endpoints principais para integração e painel IDE:
 - `GET /file` – obtém conteúdo de um arquivo.
 - `GET /actions` – retorna histórico de decisões do DevAI.
 - `GET /diff?file=<nome>` – mostra diferença da última alteração registrada.
-- `GET /approval_request` – aguarda até que o servidor solicite uma confirmação e retorna `{ "message": "texto", "token": "id" }`.
+- `GET /approval_request` – aguarda até que o servidor solicite uma confirmação e retorna `{ "message": "texto", "details": "info", "token": "id" }`.
 - `POST /approval_request` – envia `{ "approved": true|false, "token": "id" }` para responder à solicitação pendente.
 
 Se `NOTIFY_EMAIL` ou `NOTIFY_SLACK` estiverem configurados, cada pedido de aprovação gera um e-mail ou mensagem com links diretos:

--- a/devai/approval.py
+++ b/devai/approval.py
@@ -9,6 +9,7 @@ from .notifier import Notifier
 _approval_event = asyncio.Event()
 _approval_future: asyncio.Future | None = None
 _approval_message = ""
+_approval_details: str | None = None
 _approval_token = ""
 
 # Remaining actions allowed without manual approval
@@ -67,26 +68,26 @@ def requires_approval(action: str, path: str | None = None) -> bool:
     return action in WRITE_ACTIONS or action in SHELL_ACTIONS
 
 
-async def request_approval(message: str) -> bool:
+async def request_approval(message: str, details: str | None = None) -> bool:
     """Trigger approval flow in web mode and wait for result."""
-    global _approval_future, _approval_message, _approval_token
+    global _approval_future, _approval_message, _approval_details, _approval_token
     if _approval_future is not None:
         raise RuntimeError("Another approval in progress")
     _approval_future = asyncio.get_running_loop().create_future()
     _approval_message = message
+    _approval_details = details
     _approval_token = uuid4().hex
     notifier = Notifier()
     if notifier.enabled:
         base_url = f"http://localhost:{config.API_PORT}"
         approve = f"{base_url}/approval_request?token={_approval_token}&approved=true"
         reject = f"{base_url}/approval_request?token={_approval_token}&approved=false"
-        notifier.send(
-            "Confirmação necessária",
-            f"{message}\nAprovar: {approve}\nRejeitar: {reject}",
-        )
+        body = f"{message}\nAprovar: {approve}\nRejeitar: {reject}"
+        notifier.send("Confirmação necessária", body, details=details)
     _approval_event.set()
     result = await _approval_future
     _approval_future = None
+    _approval_details = None
     return bool(result)
 
 
@@ -94,15 +95,20 @@ async def wait_for_request() -> dict:
     """Wait until a request is available for the frontend."""
     await _approval_event.wait()
     _approval_event.clear()
-    return {"message": _approval_message, "token": _approval_token}
+    return {
+        "message": _approval_message,
+        "token": _approval_token,
+        "details": _approval_details,
+    }
 
 
 def resolve_request(approved: bool) -> None:
     """Resolve the current pending approval request."""
-    global _approval_future, _approval_token
+    global _approval_future, _approval_token, _approval_details
     if _approval_future and not _approval_future.done():
         _approval_future.set_result(bool(approved))
     _approval_token = ""
+    _approval_details = None
 
 
 def verify_token(token: str) -> bool:

--- a/devai/command_router.py
+++ b/devai/command_router.py
@@ -760,7 +760,10 @@ async def handle_default(
                 apply = await ui.confirm("Aplicar mudanças?")
                 model = "cli"
             else:
-                apply = await request_approval("Aplicar mudanças?")
+                apply = await request_approval(
+                    "Aplicar mudanças?",
+                    details=response,
+                )
                 model = "web"
         else:
             model = "cli"

--- a/devai/notifier.py
+++ b/devai/notifier.py
@@ -30,9 +30,12 @@ class Notifier:
         else:
             loop.create_task(coro)
 
-    def send(self, subject: str, body: str) -> None:
+    def send(self, subject: str, body: str, details: str | None = None) -> None:
         if not self.enabled:
             return
+        if details:
+            body = f"{body}\n{details}"
+
         if self.email_enabled:
             try:
                 msg = EmailMessage()

--- a/devai/tasks.py
+++ b/devai/tasks.py
@@ -376,7 +376,10 @@ class TaskManager:
                 approved = await ui.confirm("Executar testes?")
                 model = "cli"
             else:
-                approved = await request_approval("Executar testes?")
+                approved = await request_approval(
+                    "Executar testes?",
+                    details="pytest -q",
+                )
                 model = "web"
             log_decision(
                 "shell",
@@ -403,7 +406,10 @@ class TaskManager:
                 approved = await ui.confirm("Executar análise estática?")
                 model = "cli"
             else:
-                approved = await request_approval("Executar análise estática?")
+                approved = await request_approval(
+                    "Executar análise estática?",
+                    details="flake8 " + str(self.code_analyzer.code_root),
+                )
                 model = "web"
             log_decision(
                 "shell_safe",
@@ -441,7 +447,10 @@ class TaskManager:
                 approved = await ui.confirm("Executar análise de segurança?")
                 model = "cli"
             else:
-                approved = await request_approval("Executar análise de segurança?")
+                approved = await request_approval(
+                    "Executar análise de segurança?",
+                    details="bandit -r " + str(self.code_analyzer.code_root),
+                )
                 model = "web"
             log_decision(
                 "shell_safe",
@@ -477,7 +486,10 @@ class TaskManager:
                 approved = await ui.confirm("Executar pylint?")
                 model = "cli"
             else:
-                approved = await request_approval("Executar pylint?")
+                approved = await request_approval(
+                    "Executar pylint?",
+                    details="pylint " + str(self.code_analyzer.code_root),
+                )
                 model = "web"
             log_decision(
                 "shell_safe",
@@ -513,7 +525,10 @@ class TaskManager:
                 approved = await ui.confirm("Executar verificação de tipos?")
                 model = "cli"
             else:
-                approved = await request_approval("Executar verificação de tipos?")
+                approved = await request_approval(
+                    "Executar verificação de tipos?",
+                    details="mypy " + str(self.code_analyzer.code_root),
+                )
                 model = "web"
             log_decision(
                 "shell_safe",
@@ -551,7 +566,10 @@ class TaskManager:
                 approved = await ui.confirm("Executar cobertura de testes?")
                 model = "cli"
             else:
-                approved = await request_approval("Executar cobertura de testes?")
+                approved = await request_approval(
+                    "Executar cobertura de testes?",
+                    details="coverage run -m pytest -q",
+                )
                 model = "web"
             log_decision(
                 "shell",
@@ -624,8 +642,18 @@ class TaskManager:
             return {"error": str(e)}
 
         from .update_manager import UpdateManager
+        import difflib
 
         updater = UpdateManager()
+
+        diff_text = "\n".join(
+            difflib.unified_diff(
+                original.splitlines(),
+                suggestion.splitlines(),
+                fromfile=file_path,
+                tofile=file_path,
+            )
+        )
 
         def apply(p: Path) -> None:
             p.write_text(suggestion)
@@ -636,7 +664,8 @@ class TaskManager:
                 model = "cli"
             else:
                 approved = await request_approval(
-                    f"Aplicar refatoração em {file_path}?"
+                    f"Aplicar refatoração em {file_path}?",
+                    details=diff_text,
                 )
                 model = "web"
             log_decision(
@@ -671,6 +700,14 @@ class TaskManager:
 
             def apply_retry(p: Path) -> None:
                 p.write_text(suggestion)
+            diff_text_retry = "\n".join(
+                difflib.unified_diff(
+                    original.splitlines(),
+                    suggestion.splitlines(),
+                    fromfile=file_path,
+                    tofile=file_path,
+                )
+            )
 
             if requires_approval("edit"):
                 if ui:
@@ -680,7 +717,8 @@ class TaskManager:
                     model = "cli"
                 else:
                     approved = await request_approval(
-                        f"Aplicar refatoração em {file_path} (retry)?"
+                        f"Aplicar refatoração em {file_path} (retry)?",
+                        details=diff_text_retry,
                     )
                     model = "web"
                 log_decision(

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -131,7 +131,9 @@ def test_request_approval_notifies(monkeypatch):
         def __init__(self):
             self.enabled = True
 
-        def send(self, subj, body):
+        def send(self, subj, body, details=None):
+            if details:
+                body = f"{body}\n{details}"
             sent.append(body)
 
     monkeypatch.setattr("devai.approval.Notifier", DummyNotifier)

--- a/tests/test_symbolic_training_queue.py
+++ b/tests/test_symbolic_training_queue.py
@@ -17,7 +17,7 @@ async def fake_run(*a, **k):
 def test_queue_symbolic_training(monkeypatch):
     sent = []
     class DummyNotifier:
-        def send(self, subj, body):
+        def send(self, subj, body, details=None):
             sent.append(subj)
     monkeypatch.setattr("devai.notifier.Notifier", DummyNotifier)
     monkeypatch.setattr("devai.symbolic_training.run_symbolic_training", fake_run)


### PR DESCRIPTION
## Summary
- include optional `details` in approval requests
- pass diff/command data into approval requests from router and tasks
- include details in notification formatting
- document approval request details in API guide
- adjust tests for new Notifier interface

## Testing
- `pytest tests/test_approval.py tests/test_notifier.py tests/test_symbolic_training_queue.py -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848b5e7f3148320a6ac7563a0d559f1