### PR TITLE
Implement sandbox utility and integrate

### DIFF
--- a/devai/sandbox.py
+++ b/devai/sandbox.py
@@ -84,3 +84,13 @@ class Sandbox:
 
     def __exit__(self, exc_type, exc, tb) -> None:
         self.shutdown()
+
+
+def run_in_sandbox(command: List[str], timeout: int = 30) -> str:
+    """Execute ``command`` using :class:`Sandbox` with default configuration."""
+    sb = Sandbox()
+    try:
+        return sb.run(command, timeout)
+    finally:
+        sb.shutdown()
+

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,6 +1,9 @@
 import subprocess
+import asyncio
 import pytest
 from devai import sandbox
+from devai import tasks as tasks_module
+from devai import test_runner
 
 
 def test_run_executes(monkeypatch):
@@ -87,3 +90,63 @@ def test_docker_missing(monkeypatch):
     monkeypatch.setattr(sandbox.shutil, "which", lambda x: None)
     sb = sandbox.Sandbox()
     assert not sb.enabled
+
+
+def test_run_in_sandbox_delegates(monkeypatch):
+    called = {}
+
+    def fake_run(self, cmd, timeout=30):
+        called["cmd"] = cmd
+        called["timeout"] = timeout
+        return "ok"
+
+    monkeypatch.setattr(sandbox.Sandbox, "run", fake_run)
+    out = sandbox.run_in_sandbox(["echo", "hi"], timeout=5)
+    assert out == "ok"
+    assert called["cmd"] == ["echo", "hi"]
+    assert called["timeout"] == 5
+
+
+def test_static_analysis_uses_sandbox(monkeypatch):
+    class DummyAnalyzer:
+        def __init__(self):
+            self.code_root = "."
+            self.code_chunks = {}
+            self.code_graph = tasks_module.nx.DiGraph()
+            self.learned_rules = {}
+
+    analyzer = DummyAnalyzer()
+    mem = type("M", (), {"save": lambda self, *a, **k: None})()
+    tm = tasks_module.TaskManager("missing.yaml", analyzer, mem)
+
+    captured = {}
+
+    def fake_run(cmd, timeout=30):
+        captured["cmd"] = cmd
+        return "output"
+
+    monkeypatch.setattr(tasks_module, "run_in_sandbox", fake_run)
+
+    async def run():
+        return await tm._perform_static_analysis_task(tm.tasks["static_analysis"])
+
+    res = asyncio.run(run())
+    assert res == ["output"]
+    assert captured["cmd"] == ["flake8", str(analyzer.code_root)]
+
+
+def test_run_pytest_isolation(monkeypatch, tmp_path):
+    monkeypatch.setattr(test_runner.config, "TESTS_USE_ISOLATION", True)
+    monkeypatch.setattr(test_runner.config, "LOG_DIR", str(tmp_path))
+
+    captured = {}
+
+    def fake_run(cmd, timeout=30):
+        captured["cmd"] = cmd
+        return "1 passed"
+
+    monkeypatch.setattr(test_runner, "run_in_sandbox", fake_run)
+    ok, out = test_runner.run_pytest(tmp_path)
+    assert ok
+    assert "1 passed" in out
+    assert captured["cmd"] == ["pytest", "-q"]


### PR DESCRIPTION
## Summary
- add `run_in_sandbox` helper in sandbox module
- use `run_in_sandbox` inside task execution methods
- update pytest runner to rely on the helper
- expand sandbox tests to cover new utility and integration

## Testing
- `pytest tests/test_sandbox.py tests/test_test_runner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c4ed555483209457b1eb4f7febcd