### PR TITLE
Improve Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ o arquivo manualmente.
 
 O DevAI traz versões simplificadas de algumas bibliotecas (como `aiohttp` e `fastapi`) usadas apenas em testes offline. O módulo `dependency_check` avisará caso essas versões estejam ativas, recomendando a instalação dos pacotes reais.
 
+## Windows
+
+O sandbox de testes depende do Docker para isolar os processos. No Windows é
+possível utilizar o [Docker Desktop](https://docs.docker.com/desktop/) ou
+habilitar o suporte a containers no
+[WSL2](https://learn.microsoft.com/windows/wsl/install). Após instalar uma das
+opções, reinicie o terminal e confirme que o comando `docker` está disponível.
+Sem o Docker, os comandos de shell são executados diretamente, sem isolamento.
+
 ## Executando
 
 - **Servidor API**:

--- a/devai/sandbox.py
+++ b/devai/sandbox.py
@@ -23,7 +23,7 @@ class Sandbox:
                 self.enabled = True
             else:
                 logger.warning(
-                    "Docker Desktop não encontrado. Comandos rodarão sem isolamento."
+                    "Docker Desktop/WSL2 não encontrado. Comandos rodarão sem isolamento e sem limites."
                 )
                 self.enabled = False
         else:

--- a/devai/test_runner.py
+++ b/devai/test_runner.py
@@ -37,6 +37,9 @@ def _parse_output(output: str) -> str:
 def _preexec(cpu: int, mem: int) -> None:
     """Apply resource limits before executing the child process."""
     if resource is None:
+        logger.warning(
+            "Módulo 'resource' indisponível; limites não serão aplicados."
+        )
         return
     if cpu > 0:
         resource.setrlimit(resource.RLIMIT_CPU, (cpu, cpu))
@@ -67,6 +70,10 @@ def run_pytest(path: str | Path, timeout: int = 30) -> Tuple[bool, str]:
             )
 
         preexec = _limits if resource is not None else None
+        if resource is None:
+            logger.warning(
+                "Limites de CPU e memória desativados; instale o Docker para isolamento"
+            )
 
         try:
             # shell: run pytest

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,6 +1,11 @@
 import subprocess
 import asyncio
+import sys
 import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="Sandbox não suportado no Windows"
+)
 from devai import sandbox
 from devai import tasks as tasks_module
 from devai import test_runner

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -1,6 +1,12 @@
 import time
 from pathlib import Path
+import sys
+import pytest
 import devai.shadow_mode as sm
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="Limites de recursos não suportados"
+)
 
 
 def test_run_test_isolated_success(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- document Docker requirement for Windows
- warn about sandbox disabled when Docker not detected on Windows
- show warnings when `resource` module is missing
- skip sandbox and test runner tests on Windows

## Testing
- `pre-commit run --files README.md devai/test_runner.py devai/sandbox.py tests/test_sandbox.py tests/test_test_runner.py` *(fails: `pre-commit: command not found`)*
- `pytest -q` *(interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6848c97d63608320b7e61620a2003c47