### PR TITLE
Implement configurable sandbox network

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,6 +39,8 @@ RLHF_OUTPUT_DIR: ./logs/rlhf_results
 SANDBOX_IMAGE: python:3.10-slim
 SANDBOX_CPUS: "1"
 SANDBOX_MEMORY: 512m
+SANDBOX_NETWORK: none
+# SANDBOX_ALLOWED_HOSTS: []
 MAX_PROMPT_TOKENS: 1000
 APPROVAL_MODE: suggest
 DIFF_STYLE: inline  # options: inline, side_by_side

--- a/devai/config.py
+++ b/devai/config.py
@@ -73,6 +73,8 @@ class Config:
     SANDBOX_IMAGE: str = "python:3.10-slim"
     SANDBOX_CPUS: str = "1"
     SANDBOX_MEMORY: str = "512m"
+    SANDBOX_NETWORK: str = "none"
+    SANDBOX_ALLOWED_HOSTS: list[str] = field(default_factory=list)
     APPROVAL_MODE: str = "suggest"
     DIFF_STYLE: str = "inline"
     AUTO_APPROVAL_RULES: list[dict] = field(default_factory=list)
@@ -148,6 +150,10 @@ class Config:
             raise ValueError("SANDBOX_CPUS must be string or int")
         if not isinstance(self.SANDBOX_MEMORY, str):
             raise ValueError("SANDBOX_MEMORY must be string")
+        if not isinstance(self.SANDBOX_NETWORK, str):
+            raise ValueError("SANDBOX_NETWORK must be string")
+        if not isinstance(self.SANDBOX_ALLOWED_HOSTS, list):
+            raise ValueError("SANDBOX_ALLOWED_HOSTS must be a list")
         if not isinstance(self.ERROR_LOG_PATH, str):
             raise ValueError("ERROR_LOG_PATH must be string")
         if not isinstance(self.ERROR_LOG_MAX_LINES, int):

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -38,11 +38,19 @@ container também é `/app`.
 SANDBOX_IMAGE: python:3.10-slim
 SANDBOX_CPUS: "1"
 SANDBOX_MEMORY: 512m
+SANDBOX_NETWORK: none
+# SANDBOX_ALLOWED_HOSTS:
+#   - example.com
 ```
 
 Em Linux e macOS o Docker é usado quando disponível. No Windows é necessário o
 Docker Desktop; caso ausente, o DevAI tenta rodar via WSL ou executa os comandos
-diretamente exibindo um alerta.
+diretamente exibindo um alerta. Nesse caso os limites de CPU/memória e o
+controle de rede não estarão ativos.
+
+Para rodar o DevAI em um ambiente totalmente isolado é possível criar uma imagem
+Docker personalizada contendo todas as dependências (Git, compiladores, etc.) e
+definir o caminho dessa imagem em `SANDBOX_IMAGE`.
 
 ## Histórico de conversa
 


### PR DESCRIPTION
## Summary
- add `SANDBOX_NETWORK` and optional `SANDBOX_ALLOWED_HOSTS` settings
- respect these options in `Sandbox.run_command`
- document sandbox network behaviour and custom Docker images
- improve Windows warning message
- extend sandbox tests for network configuration

## Testing
- `pytest tests/test_sandbox.py::test_run_executes -q`
- `pytest tests/test_sandbox.py::test_network_option -q`
- `pytest tests/test_sandbox.py::test_allowed_hosts_creates_network -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848d33c67148320869cf295eb5d83be