### PR TITLE
Add patch utils tests and auto refactor success check

### DIFF
--- a/tests/test_patch_utils.py
+++ b/tests/test_patch_utils.py
@@ -1,0 +1,30 @@
+import difflib
+from pathlib import Path
+
+import devai.patch_utils as patch_utils
+import unidiff
+
+
+def test_apply_patch_to_file(tmp_path, monkeypatch):
+    file = tmp_path / "test.txt"
+    file.write_text("old\n")
+    diff = "".join(
+        difflib.unified_diff(
+            ["old\n"],
+            ["new\n"],
+            fromfile="a/test.txt",
+            tofile="b/test.txt",
+        )
+    )
+
+    orig = unidiff.PatchSet
+
+    def wrapper(text):
+        if hasattr(text, "read"):
+            text = text.read()
+        return orig(text)
+
+    monkeypatch.setattr(unidiff, "PatchSet", wrapper)
+
+    patch_utils.apply_patch_to_file(file, diff)
+    assert file.read_text() == "new\n"


### PR DESCRIPTION
## Summary
- add tests verifying `apply_patch_to_file`
- cover successful `_perform_auto_refactor_task` workflow

## Testing
- `pytest tests/test_patch_utils.py tests/test_tasks.py::test_auto_refactor_apply_patch_success -q`

------
https://chatgpt.com/codex/tasks/task_e_68498de55740832086d701c1920db650