### PR TITLE
Fix textual dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ python-dotenv = "*"
 trl = "*"
 networkx = "*"
 scikit-learn = "*"
+textual = "<0.31"
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ python-dotenv
 # UI dependencies
 rich
 prompt_toolkit
-textual
+textual<0.31
 unidiff
 # Optional: treinamento RLHF
 trl>=0.7


### PR DESCRIPTION
## Summary
- pin textual version for compatibility with TextLog widget

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: PytestDeprecationWarning and test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849a1ab9cc083209d3ef8ffd4fa5939