### PR TITLE
Fix sandbox mode background tasks

### DIFF
--- a/devai/core.py
+++ b/devai/core.py
@@ -255,6 +255,11 @@ class CodeMemoryAI:
         if not hasattr(self, "watchers"):
             self.watchers = {}
 
+        mode = getattr(config, "OPERATING_MODE", "standard")
+        if mode == "sandbox":
+            logger.info("Modo sandbox ativo: background tasks desativadas.")
+            return
+
         meta = MetacognitionLoop(memory=self.memory)
         task_coros = [
             ("learning_loop", self._learning_loop()),
@@ -281,9 +286,6 @@ class CodeMemoryAI:
                     auto_monitor_cycle(self.analyzer, self.memory, self.ai_model),
                 )
             )
-        elif mode == "sandbox":
-            logger.info("Modo sandbox ativo: background tasks desativadas.")
-            task_coros = []
         run_scan = False
         run_watch = False
         if config.START_MODE == "full":


### PR DESCRIPTION
## Summary
- stop background tasks from running in sandbox mode

## Testing
- `pytest tests/test_startup_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6849d2d856d0832095d53043486616dd