### PR TITLE
Update RLHF training to use TRL SFTTrainer

### DIFF
--- a/MODEL_USAGE_GUIDE.md
+++ b/MODEL_USAGE_GUIDE.md
@@ -23,3 +23,15 @@ porcentagem de respostas incompletas detectadas.  Use `model_usage` para
 avaliar a frequência de cada provedor configurado.  Os campos
 `error_percent` e `incomplete_percent` indicam, respectivamente, a taxa de
 falhas de API e de respostas que precisaram de recuperação por corte.
+
+## Fine-tuning RLHF
+
+O módulo `devai.rlhf` utiliza o `SFTTrainer` para ajustar o modelo com o
+feedback positivo registrado. Para executar, instale `transformers` e `trl` e
+rode:
+
+```bash
+python -m devai.rlhf <modelo_base> ./model_ft
+```
+
+Os artefatos de treinamento são gravados em `logs/rlhf_results`.

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ python -m devai --cli
 
 ## Treinamento RLHF
 
-Depois de registrar feedback positivo via API ou CLI, é possível refinar o modelo base utilizando a biblioteca [`trl`](https://github.com/huggingface/trl).
-Instale as dependências opcionais `transformers` e `trl` e execute:
+Depois de registrar feedback positivo via API ou CLI, é possível refinar o modelo base utilizando a biblioteca [`trl`](https://github.com/huggingface/trl) e o `SFTTrainer`.
+Instale `transformers` e `trl` via `pip` e execute:
 
 ```bash
 python -m devai.rlhf <modelo_base> ./model_ft

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ numpy
 scikit-learn>=1.3
 sentence-transformers
 faiss-cpu
-# Optional: treinamento RLHF
 transformers
 psutil
 PyYAML
@@ -19,5 +18,4 @@ rich
 prompt_toolkit
 textual<0.31
 unidiff
-# Optional: treinamento RLHF
 trl>=0.7


### PR DESCRIPTION
## Summary
- remove fallback imports and rely on transformers and trl
- convert RLHF dataset to HuggingFace Dataset
- include transformers and trl in requirements
- document RLHF training flow in README and MODEL_USAGE_GUIDE
- add unit test with real SFTTrainer training

## Testing
- `pytest tests/test_rlhf.py -q`
- `pytest -q` *(fails: TypeError in tests/test_cli.py and runtime errors in shutdown tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a11c4422c83209a62b343b6c23d03