### PR TITLE
Enable FAISS index persistence

### DIFF
--- a/MEMORY_STRUCTURE.md
+++ b/MEMORY_STRUCTURE.md
@@ -19,3 +19,8 @@ Exemplos de tags geradas automaticamente:
   `COMPLEXITY_TAG_THRESHOLD`
 - `@descontinuado` – detectado em docstrings contendo “deprecated” ou
   “obsoleto”
+
+O índice vetorial usado na busca é salvo em `faiss.index` junto com o arquivo
+`faiss_ids.json` contendo os IDs das entradas. Ambos são carregados ao iniciar o
+`MemoryManager`, evitando reindexar todo o banco. Caso deseje, você pode mudar
+esses caminhos no `config.yaml`.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ API_SECRET: "sua-chave"
 pip install -r requirements.txt
 ```
 
+O índice vetorial utilizado na busca é salvo automaticamente em `faiss.index` e
+`faiss_ids.json`. Mantenha esses arquivos para preservar o histórico de
+consultas entre execuções. Caminhos customizados podem ser definidos no
+`config.yaml` usando `INDEX_FILE` e `INDEX_IDS_FILE`.
+
 4. (Opcional) Descreva comandos de build e testes adicionais em `PROJECT_GUIDE.md`.
 
 Para executar a suíte de testes em ambiente isolado, configure no `config.yaml`:

--- a/devai/memory.py
+++ b/devai/memory.py
@@ -50,6 +50,8 @@ class MemoryManager:
         model: Optional[Any] = None,
         index: Optional[Any] = None,
         cache_size: int = 128,
+        index_file: str | None = None,
+        ids_file: str | None = None,
     ):
         self.conn = sqlite3.connect(db_file, check_same_thread=False)
         self.feedback_db = FeedbackDB()
@@ -75,6 +77,9 @@ class MemoryManager:
         self.indexed_ids: List[int] = []
         self.embedding_cache: "OrderedDict[str, Any]" = OrderedDict()
         self.embedding_cache_size = cache_size
+
+        self.index_file = index_file or config.INDEX_FILE
+        self.ids_file = ids_file or config.INDEX_IDS_FILE
 
         # Attempt to load an existing index from disk before creating a new one
         self.load_index()
@@ -172,8 +177,8 @@ class MemoryManager:
     def _load_index(self, index_file: str | None = None, ids_file: str | None = None) -> None:
         if not faiss:
             return
-        index_file = index_file or config.INDEX_FILE
-        ids_file = ids_file or config.INDEX_IDS_FILE
+        index_file = index_file or self.index_file
+        ids_file = ids_file or self.ids_file
         if not (os.path.exists(index_file) and os.path.exists(ids_file)):
             return
         self.index = faiss.read_index(index_file)
@@ -197,8 +202,8 @@ class MemoryManager:
     def _persist_index(self, index_file: str | None = None, ids_file: str | None = None) -> None:
         if not faiss or self.index is None:
             return
-        index_file = index_file or config.INDEX_FILE
-        ids_file = ids_file or config.INDEX_IDS_FILE
+        index_file = index_file or self.index_file
+        ids_file = ids_file or self.ids_file
         self._write_index_file(index_file)
         self._write_ids_file(ids_file)
 

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+from typing import Any
+
+from devai.memory import MemoryManager
+from devai.config import config
+
+class DummyModel:
+    def __init__(self):
+        self.dim = 1
+
+    def get_sentence_embedding_dimension(self):
+        return self.dim
+
+    def encode(self, text):
+        return [1.0]
+
+class FakeFaiss:
+    store: dict[str, Any] = {}
+
+    class IndexFlatL2:
+        def __init__(self, dim):
+            self.dim = dim
+            self.vectors: list[list[float]] = []
+
+        def add(self, embeddings):
+            self.vectors.extend(list(embeddings))
+
+        def search(self, query, k):
+            if not self.vectors:
+                return [[0.0]], [[0]]
+            dists = [abs(v[0] - query[0]) for v in self.vectors]
+            idx = sorted(range(len(dists)), key=lambda i: dists[i])[:k]
+            return [[dists[i] for i in idx]], [idx]
+
+    @staticmethod
+    def write_index(index, path):
+        FakeFaiss.store[path] = index
+        Path(path).write_bytes(b"dummy")
+
+    @staticmethod
+    def read_index(path):
+        return FakeFaiss.store.get(path)
+
+
+def test_search_after_reload(tmp_path, monkeypatch):
+    import devai.memory as memory_module
+
+    monkeypatch.setattr(memory_module, "faiss", FakeFaiss)
+    monkeypatch.setattr(memory_module, "np", None)
+    monkeypatch.setattr(config, "INDEX_FILE", str(tmp_path / "idx.bin"))
+    monkeypatch.setattr(config, "INDEX_IDS_FILE", str(tmp_path / "ids.json"))
+
+    db = str(tmp_path / "mem.sqlite")
+    model = DummyModel()
+
+    mem1 = MemoryManager(db, "dummy", model=model, index=None)
+    mem1.save({"type": "note", "content": "hello", "metadata": {}, "tags": []})
+    mem1.persist_index()
+
+    mem2 = MemoryManager(db, "dummy", model=model, index=None)
+    results = mem2.search("hello")
+    assert results
+    assert results[0]["content"] == "hello"


### PR DESCRIPTION
## Summary
- extend `MemoryManager` to keep FAISS index path and load/save automatically
- document index persistence in README and MEMORY_STRUCTURE
- add regression test for restoring the vector search

## Testing
- `pytest tests/test_memory_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1eccdca88320abd4eb33588d7288