### PR TITLE
Implement conversation history persistence and endpoint update

### DIFF
--- a/devai/conversation_handler.py
+++ b/devai/conversation_handler.py
@@ -45,6 +45,10 @@ class ConversationHandler:
             try:
                 data = json.loads(file.read_text())
                 self._mtimes[session_id] = file.stat().st_mtime
+                if len(data) > self.max_history:
+                    data = data[-self.max_history:]
+                    file.write_text(json.dumps(data, indent=2))
+                    self._mtimes[session_id] = file.stat().st_mtime
                 return data
             except Exception:
                 return []
@@ -114,6 +118,11 @@ class ConversationHandler:
                 self.conversation_context[session_id] = self._load_session(session_id)
         else:
             self.conversation_context.setdefault(session_id, [])
+
+        hist = self.conversation_context[session_id]
+        if len(hist) > self.max_history:
+            self.conversation_context[session_id] = hist[-self.max_history:]
+            self._save_session(session_id)
         return self.conversation_context[session_id]
 
     def _summarize_and_store(self, session_id: str, hist: List[Dict[str, str]]) -> None:

--- a/devai/core.py
+++ b/devai/core.py
@@ -388,7 +388,7 @@ class CodeMemoryAI:
             return StreamingResponse(event_gen(), media_type="text/event-stream")
 
         @self.app.post("/reset_conversation")
-        async def reset_conversation(session_id: str = "default"):
+        async def reset_conversation(session_id: str):
             self.conv_handler.reset(session_id)
             if session_id == "default":
                 self.conversation = self.conv_handler.history("default")

--- a/tests/test_conversation_history.py
+++ b/tests/test_conversation_history.py
@@ -1,0 +1,76 @@
+import json
+import asyncio
+import types
+import sys
+from types import SimpleNamespace
+from datetime import datetime
+
+sys.modules.setdefault('transformers', SimpleNamespace())
+sys.modules.setdefault('devai.rlhf', SimpleNamespace(RLFineTuner=lambda *a, **k: None))
+
+from devai.conversation_handler import ConversationHandler
+from devai.core import CodeMemoryAI
+from devai.config import config
+
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None, temperature=0.0):
+        return "ok"
+
+
+def _setup_ai(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "LOG_DIR", str(tmp_path))
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
+    ai.analyzer = types.SimpleNamespace(graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now())
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.reason_stack = []
+    ai.double_check = False
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_get(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = app.post = fake_get
+    app.mount = lambda *a, **k: None
+    ai.app = app
+    CodeMemoryAI._setup_api_routes(ai)
+    return ai, record
+
+
+def test_history_auto_saved(tmp_path):
+    handler = ConversationHandler(history_dir=tmp_path)
+    handler.append("s", "user", "hi")
+    handler.append("s", "assistant", "hello")
+    file = handler._history_file("s")
+    assert file.exists()
+    data = json.loads(file.read_text())
+    assert data == handler.history("s")
+
+
+def test_history_limit_enforced(tmp_path):
+    handler = ConversationHandler(history_dir=tmp_path)
+    for i in range(12):
+        handler.append("s", "user", str(i))
+    assert len(handler.history("s")) == handler.max_history
+    data = json.loads(handler._history_file("s").read_text())
+    assert len(data) == handler.max_history
+    assert data[0]["content"] == "2"
+    new_handler = ConversationHandler(history_dir=tmp_path)
+    assert len(new_handler.history("s")) == handler.max_history
+
+
+def test_reset_conversation_endpoint(monkeypatch, tmp_path):
+    ai, record = _setup_ai(monkeypatch, tmp_path)
+    ai.conv_handler.append("s", "user", "hi")
+    file = ai.conv_handler._history_file("s")
+    assert file.exists()
+    fn = record["/reset_conversation"]
+    result = asyncio.run(fn(session_id="s"))
+    assert result["status"] == "reset"
+    assert ai.conv_handler.history("s") == []
+    assert not file.exists()


### PR DESCRIPTION
## Summary
- enforce max session history trimming and auto-save in `ConversationHandler`
- require `session_id` on `/reset_conversation` endpoint
- cover conversation history logic in new tests

## Testing
- `pytest tests/test_conversation_history.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a268b39c48320a1cf3ddd40f8b50a