### PR TITLE
Add architecture and API docs

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -1,16 +1,66 @@
 # Guia de API
 
-Endpoints principais para integração e painel IDE:
+A aplicação expõe uma API FastAPI para interação com a IA e operações de gerenciamento de arquivos. Abaixo estão todos os endpoints disponíveis com exemplos de chamada usando `curl`.
+
+## Conversa e memória
 - `POST /analyze` – gera resposta do modelo.
-- `GET /files` – lista arquivos.
-- `GET /file` – obtém conteúdo de um arquivo.
-- `GET /actions` – retorna histórico de decisões do DevAI.
-- `GET /diff?file=<nome>` – mostra diferença da última alteração registrada.
-- `GET /approval_request` – aguarda até que o servidor solicite uma confirmação e retorna `{ "message": "texto", "details": "info", "token": "id" }`.
-- `POST /approval_request` – envia `{ "approved": true|false, "token": "id" }` para responder à solicitação pendente.
+  ```bash
+  curl -X POST http://localhost:8000/analyze -d "query=print('ola')"
+  ```
+- `GET /analyze_stream` – versão em streaming do endpoint anterior.
+  ```bash
+  curl "http://localhost:8000/analyze_stream?query=exemplo"
+  ```
+- `POST /reset_conversation` – reinicia o histórico de uma sessão.
+  ```bash
+  curl -X POST http://localhost:8000/reset_conversation -d "session_id=default"
+  ```
+- `POST /session/reset` – remove todos os dados de uma sessão.
+- `GET /session/history` – recupera o histórico completo da sessão.
+- `GET /history` – alias para o histórico da sessão padrão.
+- `POST /analyze_deep` – análise detalhada retornando plano e resposta.
+- `GET /memory` – busca memórias salvas (`query`, `top_k`, `level`).
+- `POST /feedback` – registra feedback `{memory_id, is_positive}`.
 
-Se `NOTIFY_EMAIL` ou `NOTIFY_SLACK` estiverem configurados, cada pedido de aprovação gera um e-mail ou mensagem com links diretos:
-`http://localhost:<porta>/approval_request?token=<id>&approved=true` ou `...&approved=false`.
-Ao clicar, o endpoint `POST /approval_request` é acionado e a decisão é registrada.
+## Arquivos
+- `GET /files` – lista diretórios abaixo de `CODE_ROOT`.
+  ```bash
+  curl "http://localhost:8000/files?path=subpasta"
+  ```
+- `GET /file` – retorna linhas de um arquivo (`file`, `start`, `end`).
+- `POST /file/edit` – edita linha específica (requer token).
+- `POST /file/create` – cria novo arquivo (requer token).
+- `POST /file/delete` – remove arquivo (requer token).
+- `POST /dir/create` – cria diretório (requer token).
+- `POST /dir/delete` – remove diretório (requer token).
+- `GET /file_history` – histórico de modificações de um arquivo.
+- `GET /diff` – diff da última alteração de um arquivo.
 
-Estes endpoints permitem integração futura com VSCode ou JetBrains.
+## Controle de refatoração
+- `POST /dry_run` – executa simulação de patch e testes.
+- `POST /apply_refactor` – aplica código sugerido (requer token).
+- `GET /deep_analysis` – gera relatório completo do projeto.
+
+## Monitoramento e tarefas
+- `GET /status` – informações gerais e tarefas em execução.
+- `GET /metrics` – métricas de CPU e memória.
+- `GET /logs/recent` – últimos registros de log.
+- `GET /admin` – status de indexação.
+- `POST /admin/rescan` – força nova varredura de código.
+- `GET /auto_monitor` – executa ciclo de monitoramento automático.
+- `GET /monitor/history` – histórico das execuções do monitor.
+- `GET /complexity/history` – evolução da complexidade média.
+- `GET /metacognition/summary` – arquivos com baixa pontuação.
+- `POST /memory/optimize` – compacta e remove memórias antigas.
+- `POST /learning/lessons` – resume lições aprendidas.
+- `POST /symbolic_training` – dispara treinamento simbólico (requer token).
+- `POST /train/rlhf` – executa fine‑tuning RLHF (requer token).
+
+## Aprovação
+- `GET /approval_request` – aguarda solicitação de aprovação e retorna `{message, details, token}`.
+- `POST /approval_request` – envia decisão `{approved, token}`.
+- `GET /actions` – lista de decisões gravadas.
+- `GET /session/context` – exibe contexto resumido da sessão.
+- `GET /context/search` – procura mensagens com uma tag específica.
+
+Todos os endpoints que exigem autenticação usam o token definido em `API_SECRET` via parâmetro `token`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,24 @@
 Obrigado por querer contribuir! Siga estas etapas para propor melhorias:
 
 1. Crie um fork do repositório e abra sua branch de trabalho.
-2. Execute `pytest` para garantir que os testes continuam passando.
-3. Utilize `flake8` e `bandit` para verificar qualidade e segurança.
-4. Envie um pull request descrevendo suas mudanças.
+2. Instale as dependências de desenvolvimento e execute `pre-commit install`.
+3. Rode `pre-commit run --all-files` para aplicar `black`, `flake8`, `pylint` e `bandit` automaticamente.
+4. Execute `pytest` para garantir que a suíte continua verde.
+5. Envie um pull request descrevendo suas mudanças.
+
+## Estilo de código
+- Siga a convenção PEP8.
+- Utilize `black` para formatação e `isort` para organizar imports (já incluídos no pre-commit).
+
+## Como rodar a suíte de testes
+- Testes unitários podem ser executados com:
+  ```bash
+  pytest
+  ```
+- Também é possível iniciar a CLI e usar o gerenciador de tarefas:
+  ```bash
+  python -m devai --cli
+  /tarefa run_tests
+  ```
 
 Feedback e sugestões são sempre bem-vindos.

--- a/README.md
+++ b/README.md
@@ -272,3 +272,52 @@ Melhorias em andamento:
 - (adicione novas ideias aqui)
 
 Uma versão resumida deste documento está disponível em `README_en.md` para facilitar contribuições internacionais.
+
+## Arquitetura
+
+Cada arquivo em `devai/` possui uma responsabilidade específica:
+- `__init__.py` – inicialização do pacote.
+- `__main__.py` – ponto de entrada para `python -m devai`.
+- `ai_model.py` – comunicação segura com o modelo de linguagem.
+- `analyzer.py` – análise do código do projeto e grafo de dependências.
+- `api_schemas.py` – modelos Pydantic usados pela API.
+- `approval.py` – fila de solicitações de aprovação.
+- `auto_review.py` – geração de revisões automáticas.
+- `cli.py` – interface de linha de comando baseada em Rich.
+- `command_router.py` – roteamento dos comandos da CLI.
+- `complexity_tracker.py` – registro histórico da complexidade do projeto.
+- `config.py` – carregamento de configuração e logger.
+- `conversation_handler.py` – gerenciamento de múltiplas sessões de conversa.
+- `core.py` – orquestrador principal e servidor FastAPI.
+- `decision_log.py` – armazenamento de decisões aprovadas.
+- `dependency_check.py` – alerta sobre dependências simplificadas.
+- `dialog_summarizer.py` – sumarização de diálogos longos.
+- `error_handler.py` – persistência de erros.
+- `feedback.py` – registro de feedback para RLHF.
+- `file_history.py` – controle de histórico de arquivos editados.
+- `intent_classifier.py` – classificador de intenções do usuário.
+- `intent_router.py` – despacho de comandos conforme a intenção.
+- `learning_engine.py` – consolidação de lições aprendidas.
+- `lint.py` – verificação rápida de TODOs e afins.
+- `log_monitor.py` – monitoramento de logs de execução.
+- `memory.py` – base vetorial de memórias e busca.
+- `metacognition.py` – avaliação contínua de desempenho.
+- `monitor_engine.py` – ciclo de monitoramento automático.
+- `notifier.py` – envio opcional de notificações.
+- `patch_utils.py` – utilidades para aplicar patches.
+- `plugin_manager.py` – carregamento de plugins externos.
+- `pydantic_fallback.py` – versão reduzida do Pydantic para testes.
+- `prompt_engine.py` – construção dinâmica de prompts.
+- `prompt_utils.py` – funções auxiliares para prompts.
+- `rlhf.py` – rotina de fine‑tuning por feedback.
+- `sandbox.py` – execução isolada de comandos.
+- `shadow_mode.py` – simulação de alterações sem aplicar.
+- `symbolic_memory_tagger.py` – marcação simbólica de memórias.
+- `symbolic_training.py` – treinamento a partir de regras simbólicas.
+- `symbolic_verification.py` – verificação de invariantes simbólicos.
+- `tasks.py` – gerenciador de tarefas automatizadas.
+- `test_runner.py` – executor de testes do projeto.
+- `tui.py` – interface textual opcional.
+- `ui.py` – pequena interface web.
+- `update_manager.py` – aplicação de mudanças com rollback.
+- `yaml_fallback.py` – leitor simples de YAML quando PyYAML não está instalado.


### PR DESCRIPTION
## Summary
- document responsibilities of each module under devai
- expand API guide with all FastAPI endpoints
- update contributing instructions on style and running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_684a2e5aef80832094bed7d404cf566e