### PR TITLE
Ensure pre-commit runs tests and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
   pull_request:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -15,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest flake8 bandit coverage mypy pylint
+          pip install pytest flake8 bandit coverage mypy pylint coverage-badge
       - name: Lint
         run: flake8 devai
       - name: Security
@@ -27,4 +29,17 @@ jobs:
       - name: Test
         run: pytest -q
       - name: Coverage
-        run: coverage run -m pytest -q && coverage report
+        run: |
+          coverage run -m pytest -q
+          coverage report
+          coverage xml
+          coverage-badge -o coverage.svg -f
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-badge
+          path: coverage.svg
+      - name: Upload badge to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: coverage.svg

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,30 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
-  - repo: https://github.com/PyCQA/pylint
-    rev: v3.1.0
-    hooks:
-      - id: pylint
-        entry: pylint -E devai
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 24.3.0
     hooks:
       - id: black
         language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        args: ["--ignore-missing-imports"]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.6
     hooks:
       - id: bandit
         args: ["-r", "devai"]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        types: [python]
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.1.0
+    hooks:
+      - id: pylint
+        entry: pylint -E devai

--- a/README.md
+++ b/README.md
@@ -195,7 +195,14 @@ Instale as dependências de desenvolvimento e execute:
 pytest
 ```
 
-O projeto inclui um arquivo `pyproject.toml` para facilitar a instalação das dependências e um arquivo `.pre-commit-config.yaml` com linters automáticos. Após instalar o `pre-commit`, execute `pre-commit install` para habilitar as verificações antes de cada commit.
+O projeto inclui um arquivo `pyproject.toml` para facilitar a instalação das dependências e um arquivo `.pre-commit-config.yaml` com linters automáticos. Para habilitar as verificações locais instale e configure o `pre-commit`:
+
+```bash
+pip install pre-commit
+pre-commit install
+# opcional: roda todos os checks de uma vez
+pre-commit run --all-files
+```
 
 ## Plugins
 


### PR DESCRIPTION
## Summary
- configure hooks in `.pre-commit-config.yaml` to run flake8, mypy, bandit and pytest
- add instructions in README about enabling pre-commit hooks
- publish coverage badge on CI and attach badge to releases

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml .github/workflows/ci.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trl')*

------
https://chatgpt.com/codex/tasks/task_e_684a37bd6b3c832095f1298a5a9fdd8c