### PR TITLE
UI plan panel and fallback logic

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -57,7 +57,10 @@
   <div id="aiPanel">
     <h3>Painel IA</h3>
     <div id="ia-panel" class="chat"></div>
-    <pre id="planOutput"></pre>
+    <div id="planPanel" class="info-box">
+      <h4>📝 Plano</h4>
+      <pre id="planOutput"></pre>
+    </div>
     <pre id="aiOutput"></pre>
     <button id="toggleReason" style="display:none;" onclick="toggleReasoning()">👁️ Ver raciocínio da IA</button>
     <button id="showContextBtn" style="display:none;" onclick="toggleContext()">🧠 Contexto Atual</button>

--- a/static/style.css
+++ b/static/style.css
@@ -146,3 +146,12 @@
   border-radius:4px;
 }
 .modal-content button{margin:0 5px;}
+
+#planPanel pre{
+  margin:0;
+  white-space:pre-wrap;
+}
+
+#planPanel{
+  margin-bottom:8px;
+}

--- a/tests/test_analyze_deep_response_structure.py
+++ b/tests/test_analyze_deep_response_structure.py
@@ -110,3 +110,12 @@ def test_split_when_ignoring_max_tokens():
     assert result_long["plan"].startswith("1.")
     assert len(result_long["response"].split()) > 10
     assert "RESPOSTA" not in result_long["plan"]
+
+
+def test_plan_panel_present():
+    with open("static/index.html", encoding="utf-8") as f:
+        html = f.read()
+    assert "id=\"planPanel\"" in html
+    start = html.index("id=\"planPanel\"")
+    subset = html[start: html.find("</div>", start)]
+    assert "id=\"planOutput\"" in subset


### PR DESCRIPTION
## Summary
- show reasoning plan in its own `planPanel` section in the UI
- add CSS styles for new panel
- improve `/analyze_deep` fallback by parsing unexpected markers
- allow optional `rlhf` dependency
- test HTML contains the new plan panel

## Testing
- `pytest -k analyze_deep_response_structure -vv`


------
https://chatgpt.com/codex/tasks/task_e_684a3b791a9c83208e85601ddf7069a5