### PR TITLE
Add complexity trend tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,16 @@ Caso escolha lembrar uma decisão, será solicitado por quantos dias ela deve pe
 ### Histórico de complexidade
 
 Com o servidor API rodando é possível consultar `/complexity/history` para obter
-o histórico de variações de complexidade salvas em `complexity_history.json`.
-O endpoint retorna uma lista de registros e a tendência média recente:
+o histórico de variações de complexidade salvas em `complexity_history.json` e
+a evolução da tendência gravada em `complexity_trend.json`.
+O endpoint retorna uma lista de registros, a tendência média recente e os dados
+agregados de tendência:
 
 ```json
 {
   "history": [{"timestamp": "2024-01-01T12:00:00", "average_complexity": 3.2}],
-  "trend": -0.1
+  "trend": -0.1,
+  "trend_history": [{"timestamp": "2024-01-01T12:00:00", "trend": -0.1}]
 }
 ```
 

--- a/devai/complexity_tracker.py
+++ b/devai/complexity_tracker.py
@@ -5,11 +5,17 @@ from typing import List, Dict
 
 
 class ComplexityTracker:
-    """Save average complexity over time to a JSON file."""
+    """Save average complexity and trend over time to JSON files."""
 
-    def __init__(self, path: str = "complexity_history.json") -> None:
+    def __init__(
+        self,
+        path: str = "complexity_history.json",
+        trend_path: str | None = None,
+    ) -> None:
         self.path = path
+        self.trend_path = trend_path or "complexity_trend.json"
         self.history: List[Dict[str, float]] = []
+        self.trend_history: List[Dict[str, float]] = []
         self._load()
 
     def _load(self) -> None:
@@ -20,21 +26,36 @@ class ComplexityTracker:
             except Exception:
                 self.history = []
 
+        if os.path.exists(self.trend_path):
+            try:
+                with open(self.trend_path, "r", encoding="utf-8") as f:
+                    self.trend_history = json.load(f)
+            except Exception:
+                self.trend_history = []
+
     def record(self, average: float) -> None:
         entry = {
             "timestamp": datetime.now().isoformat(),
             "average_complexity": average,
         }
         self.history.append(entry)
+        trend = self.summarize_trend()
+        trend_entry = {"timestamp": entry["timestamp"], "trend": trend}
+        self.trend_history.append(trend_entry)
         try:
             with open(self.path, "w", encoding="utf-8") as f:
                 json.dump(self.history, f, indent=2)
+            with open(self.trend_path, "w", encoding="utf-8") as f:
+                json.dump(self.trend_history, f, indent=2)
         except Exception:
             # Tolerate failures silently
             pass
 
     def get_history(self) -> List[Dict[str, float]]:
         return list(self.history)
+
+    def get_trend_history(self) -> List[Dict[str, float]]:
+        return list(self.trend_history)
 
     def summarize_trend(self, window: int = 5) -> float:
         """Return the average change between the last ``window`` records."""

--- a/devai/core.py
+++ b/devai/core.py
@@ -729,8 +729,13 @@ class CodeMemoryAI:
         @self.app.get("/complexity/history")
         async def complexity_history(limit: int = 100, window: int = 5):
             history = self.complexity_tracker.get_history()[-limit:]
+            trend_history = self.complexity_tracker.get_trend_history()[-limit:]
             trend = self.complexity_tracker.summarize_trend(window)
-            return {"history": history, "trend": trend}
+            return {
+                "history": history,
+                "trend": trend,
+                "trend_history": trend_history,
+            }
 
         @self.app.get("/metacognition/summary")
         async def metacognition_summary():

--- a/tests/test_complexity_history.py
+++ b/tests/test_complexity_history.py
@@ -9,16 +9,22 @@ class DummyModel:
         return "ok"
 
 class DummyTracker:
-    def __init__(self, hist, trend):
+    def __init__(self, hist, trend, trend_hist):
         self._hist = hist
         self._trend = trend
+        self._trend_hist = trend_hist
+
     def get_history(self):
         return self._hist
+
+    def get_trend_history(self):
+        return self._trend_hist
+
     def summarize_trend(self, window=5):
         return self._trend
 
 
-def _setup_ai(history, trend):
+def _setup_ai(history, trend, trend_history):
     ai = object.__new__(CodeMemoryAI)
     ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
     ai.analyzer = types.SimpleNamespace(graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now())
@@ -27,7 +33,7 @@ def _setup_ai(history, trend):
     ai.conv_handler = ConversationHandler(memory=ai.memory)
     ai.reason_stack = []
     ai.double_check = False
-    ai.complexity_tracker = DummyTracker(history, trend)
+    ai.complexity_tracker = DummyTracker(history, trend, trend_history)
     record = {}
     app = types.SimpleNamespace()
     def fake_get(path):
@@ -48,8 +54,32 @@ def test_complexity_history_endpoint():
         {"timestamp": "t2", "average_complexity": 2.0},
     ]
     trend = 0.5
-    record = _setup_ai(history, trend)
+    trend_history = [
+        {"timestamp": "t1", "trend": 0.1},
+        {"timestamp": "t2", "trend": 0.5},
+    ]
+    record = _setup_ai(history, trend, trend_history)
     fn = record["/complexity/history"]
     result = asyncio.run(fn())
     assert result["history"] == history
     assert result["trend"] == trend
+    assert result["trend_history"] == trend_history
+
+
+def test_complexity_history_aggregated():
+    history = [
+        {"timestamp": "t1", "average_complexity": 1.0},
+        {"timestamp": "t2", "average_complexity": 2.0},
+        {"timestamp": "t3", "average_complexity": 3.0},
+    ]
+    trend_history = [
+        {"timestamp": "t1", "trend": 0.0},
+        {"timestamp": "t2", "trend": 0.5},
+        {"timestamp": "t3", "trend": 1.0},
+    ]
+    tracker_trend = 1.0
+    record = _setup_ai(history, tracker_trend, trend_history)
+    fn = record["/complexity/history"]
+    result = asyncio.run(fn(limit=2))
+    assert result["history"] == history[-2:]
+    assert result["trend_history"] == trend_history[-2:]


### PR DESCRIPTION
## Summary
- persist complexity trends to a file
- expose trend history through `/complexity/history`
- test aggregated trend data
- document complexity trend history

## Testing
- `pytest tests/test_complexity_history.py tests/test_autoreview_complexity.py -q`
- `pip install transformers==4.38.2 --quiet` *(for test dependencies)*
- `pip install torch --quiet` *(failed to install due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684a3ddcba348320afd17742b628e669