### PR TITLE
Add detection for truncated responses

### DIFF
--- a/MODEL_USAGE_GUIDE.md
+++ b/MODEL_USAGE_GUIDE.md
@@ -16,6 +16,12 @@ poucos; caso o modelo não ofereça streaming, o texto completo é retornado de 
 única vez. Consulte [limitations.md](limitations.md) para detalhes e para
 entender eventuais variações observadas no endpoint `/analyze_deep`.
 
+Quando a saída é interrompida, cada provedor pode incluir mensagens diferentes,
+como `stop reason: length` ou avisos de "content truncated". O método
+`is_response_incomplete` reconhece essas variações para solicitar uma
+continuação automática e contabiliza o evento em `incomplete_responses` nas
+métricas.
+
 ## Estatísticas de uso
 
 O endpoint `/metrics` agora mostra contadores de chamadas por modelo e a

--- a/devai/ai_model.py
+++ b/devai/ai_model.py
@@ -34,6 +34,8 @@ def is_response_incomplete(response: str) -> bool:
         return True
     if text.endswith("..."):
         return True
+    if re.search(r"(truncat|cortad|stop reason)", text, re.IGNORECASE):
+        return True
     if re.search(
         r"\b(portanto|logo|entao|isso significa que|ou seja|em conclusao)$",
         text,

--- a/tests/test_model_usage.py
+++ b/tests/test_model_usage.py
@@ -1,0 +1,32 @@
+import asyncio
+from devai.ai_model import AIModel, is_response_incomplete
+from devai.config import metrics
+
+class DummyProvider:
+    def __init__(self):
+        self.calls = 0
+    async def __call__(self, *a, **kw):
+        self.calls += 1
+        metrics.record_model_usage("dummy")
+        text = "codigo" if self.calls == 1 else " finalizado."
+        if is_response_incomplete(text):
+            metrics.record_incomplete()
+        return text
+
+def test_incomplete_response_records_metrics():
+    ai = object.__new__(AIModel)
+    provider = DummyProvider()
+    ai.generate = provider
+    metrics.incomplete_responses = 0
+    metrics.model_usage.clear()
+    async def run():
+        return await AIModel.safe_api_call(ai, "q", 20)
+    result = asyncio.run(run())
+    assert provider.calls == 2
+    assert metrics.incomplete_responses == 1
+    assert metrics.model_usage["dummy"] == 2
+    assert "reconstruída" in result
+
+def test_stop_reason_detection():
+    text = "Conteúdo cortado - stop reason: length"
+    assert is_response_incomplete(text)


### PR DESCRIPTION
## Summary
- detect truncated messages that include "truncated" or "stop reason" phrases
- test provider metrics for incomplete responses
- document how providers may interrupt outputs

## Testing
- `pytest tests/test_model_usage.py -q`
- `pytest -q` *(fails: ValueError: rich.__spec__ is None / missing heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_684a44b843b48320896f1d007189e826