### PR TITLE
Add apply_patch util and multi-file tests

### DIFF
--- a/devai/__init__.py
+++ b/devai/__init__.py
@@ -1,9 +1,10 @@
 from .conversation_handler import ConversationHandler
 from .dialog_summarizer import DialogSummarizer
-from .patch_utils import apply_patch_to_file, split_diff_by_file
+from .patch_utils import apply_patch_to_file, split_diff_by_file, apply_patch
 
 __all__ = [
     "ConversationHandler",
+    "apply_patch",
     "DialogSummarizer",
     "apply_patch_to_file",
     "split_diff_by_file",

--- a/devai/core.py
+++ b/devai/core.py
@@ -615,7 +615,7 @@ class CodeMemoryAI:
                 return {"error": "unauthorized"}
 
             from .update_manager import UpdateManager
-            from .patch_utils import split_diff_by_file, apply_patch_to_file
+            from .patch_utils import split_diff_by_file, apply_patch
 
             path = Path(req.file_path)
             old_lines = path.read_text().splitlines()
@@ -630,7 +630,7 @@ class CodeMemoryAI:
                 return {"error": "invalid_patch"}
 
             def apply_func(p: Path, d=patch_text) -> None:
-                apply_patch_to_file(p, d)
+                apply_patch(d)
 
             updater = UpdateManager()
             success = updater.safe_apply(path, apply_func, keep_backup=True)

--- a/devai/tasks.py
+++ b/devai/tasks.py
@@ -18,7 +18,7 @@ from .test_runner import run_pytest
 from .sandbox import run_in_sandbox
 from .approval import requires_approval, request_approval
 from .decision_log import log_decision
-from .patch_utils import split_diff_by_file, apply_patch_to_file
+from .patch_utils import split_diff_by_file, apply_patch
 import re
 
 
@@ -621,7 +621,7 @@ class TaskManager:
             return {"error": "Patch inválido"}
 
         def apply(p: Path, d=patch) -> None:
-            apply_patch_to_file(p, d)
+            apply_patch(d)
 
         if requires_approval("edit"):
             if ui:
@@ -684,7 +684,7 @@ class TaskManager:
                 return {"error": "Patch inválido"}
 
             def apply_retry(p: Path, d=patch_retry) -> None:
-                apply_patch_to_file(p, d)
+                apply_patch(d)
 
             if requires_approval("edit"):
                 if ui:


### PR DESCRIPTION
## Summary
- add `apply_patch` for applying unified diffs across multiple files atomically
- expose helper in `__init__`
- use `apply_patch` in auto refactor logic and web API
- support patch application in command router
- update unit tests and add multi-file patch cases

## Testing
- `pre-commit run --files devai/patch_utils.py devai/__init__.py devai/tasks.py devai/core.py devai/command_router.py tests/test_patch_utils.py tests/test_tasks.py tests/test_cli.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684a508d035c8320bffb9d8737f4fffb