### PR TITLE
Fix TRL dependency pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ rich
 prompt_toolkit
 textual<0.31
 unidiff
-trl>=0.7
+trl==0.7.11


### PR DESCRIPTION
## Summary
- pin `trl` dependency to version 0.7.11 to match code expectations

## Testing
- `flake8 devai` *(fails: style violations)*
- `pylint devai` *(fails: many warnings)*
- `mypy devai` *(fails: typing errors and interrupted)*
- `bandit -r devai`
- `pytest` *(fails: TypeError due to SFTTrainer API mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_684c64d02ef883209c9de85e7057e2ec