### PR TITLE
Fix diff rendering and patch search

### DIFF
--- a/devai/patch_utils.py
+++ b/devai/patch_utils.py
@@ -97,6 +97,12 @@ def apply_patch(diff_text: str) -> None:
     try:
         for path_str, patch in patches.items():
             path = Path(path_str)
+            if not path.exists():
+                matches = list(Path.cwd().rglob(path_str))
+                if len(matches) == 1:
+                    path = matches[0]
+                elif not matches:
+                    raise FileNotFoundError(path_str)
             backups[path] = path.read_text() if path.exists() else None
             apply_patch_to_file(path, patch)
             applied.append(path)

--- a/devai/ui.py
+++ b/devai/ui.py
@@ -7,7 +7,6 @@ from typing import Iterable, List
 
 from rich.console import Console
 from rich.panel import Panel
-from rich.syntax import Syntax
 from rich.text import Text
 from rich.table import Table
 
@@ -171,7 +170,7 @@ class CLIUI:
                     table.add_row(t, t)
             renderable = table
         else:
-            renderable = Syntax(collapsed, "diff")
+            renderable = collapsed
 
         if self.diff_panel is not None:
             try:


### PR DESCRIPTION
## Summary
- tweak CLI diff rendering to store collapsed text
- improve patch search across working tree

## Testing
- `flake8 devai/ui.py devai/patch_utils.py`
- `pylint devai/ui.py devai/patch_utils.py`
- `bandit -r devai`
- `mypy devai/ui.py devai/patch_utils.py` *(fails: Interrupted)*
- `pytest` *(fails: 14 failed, 166 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684c8547133c8320a79648c5ceb0129a