### PR TITLE
Add dev checks script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,12 @@ Obrigado por querer contribuir! Siga estas etapas para propor melhorias:
   /tarefa run_tests
   ```
 
+## Verificações de desenvolvimento
+
+Execute todos os linters e testes de uma vez com o script abaixo:
+
+```bash
+./scripts/dev_checks.sh
+```
+
 Feedback e sugestões são sempre bem-vindos.

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Executa verificacoes de desenvolvimento padrao para o DevAI-R1.
+
+set -euo pipefail
+
+flake8 devai
+pylint devai
+mypy devai
+bandit -r devai
+pytest


### PR DESCRIPTION
## Summary
- add `scripts/dev_checks.sh` to run lint, type check, security scan and tests
- document dev check script usage in CONTRIBUTING

## Testing
- `scripts/dev_checks.sh` *(fails: flake8 issues)*
- `pytest` *(fails: 12 failed, 168 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3469af08320b2d38c470b2e179e