### PR TITLE
Add quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Assistente de desenvolvimento baseado em IA com suporte a contextos de até **160k tokens** via OpenRouter. Agora inclui validação de configuração e autenticação com tokens JWT.
 
+Para um guia rápido de configuração, veja [docs/QUICKSTART.md](docs/QUICKSTART.md).
+
+
 ## Principais recursos
 
 - **Memória persistente** com busca vetorial (FAISS)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,28 @@
+# Guia Rápido
+
+Este guia resume os passos iniciais para rodar o DevAI-R1.
+
+1. **Clone o repositório**
+   ```bash
+   git clone <repo>
+   cd DevAI-R1
+   ```
+2. **Instale as dependências**
+   ```bash
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
+   ```
+3. **Copie e ajuste a configuração**
+   ```bash
+   cp config.example.yaml config.yaml
+   # edite conforme necessário
+   ```
+4. **Crie o arquivo `.env`**
+   ```bash
+   echo OPENROUTER_API_KEY=suachave > .env
+   ```
+5. **Execute as verificações básicas**
+   ```bash
+   pre-commit install
+   pytest
+   ```


### PR DESCRIPTION
## Summary
- add docs/QUICKSTART.md with simplified setup instructions
- reference the quickstart guide in README

## Testing
- `flake8 devai`
- `timeout 5s pylint devai` *(fails: timeout/no output)*
- `mypy devai` *(fails: type errors and interrupt)*
- `bandit -r devai`
- `pytest` *(fails: multiple test failures due to missing models)*

------
https://chatgpt.com/codex/tasks/task_e_684e3a783b9c8320bb5ce944c60ad45f