### PR TITLE
Improve plugin_manager style

### DIFF
--- a/devai/__main__.py
+++ b/devai/__main__.py
@@ -5,6 +5,7 @@ import difflib
 import tempfile
 import subprocess
 import hashlib
+import shutil
 from pathlib import Path
 
 from .config import config
@@ -157,7 +158,7 @@ def main():
                 diff, tests_ok, test_out, sim_id, patch_path = simulate_update(
                     file_path, new_code
                 )
-                patch_hash = hashlib.sha1(diff.encode("utf-8")).hexdigest()
+                patch_hash = hashlib.sha256(diff.encode("utf-8")).hexdigest()
                 evaluation = await evaluate_change_with_ia(diff)
 
                 if side_by_side:
@@ -186,8 +187,11 @@ def main():
                     )
                     if not success and rollback:
                         # shell: rollback patch
+                        git_path = shutil.which("git") or "git"
                         subprocess.run(
-                            ["git", "apply", "-R", patch_path], cwd=config.CODE_ROOT
+                            [git_path, "apply", "-R", patch_path],
+                            cwd=config.CODE_ROOT,
+                            check=True,
                         )
                     action = "shadow_approved" if success else "shadow_failed"
                 else:

--- a/devai/analyzer.py
+++ b/devai/analyzer.py
@@ -124,7 +124,7 @@ class CodeAnalyzer:
                 file_path, "r", encoding="utf-8", errors="ignore"
             ) as f:
                 content = await f.read()
-            file_hash = hashlib.md5(content.encode()).hexdigest()
+            file_hash = hashlib.sha256(content.encode()).hexdigest()
             if (
                 str(file_path) in self.file_hashes
                 and self.file_hashes[str(file_path)] == file_hash

--- a/devai/config.py
+++ b/devai/config.py
@@ -2,7 +2,9 @@ import os
 import logging
 import logging.handlers
 from dataclasses import dataclass, field, fields, MISSING
-from typing import Dict, Any
+from typing import Any, Dict, Optional
+from types import ModuleType
+from config_utils import load_config
 
 try:
     from dotenv import load_dotenv  # type: ignore
@@ -10,15 +12,21 @@ try:
     load_dotenv()
 except Exception:
     pass
+
+psutil: Optional[ModuleType]
 try:
-    import psutil  # type: ignore
+    import psutil as psutil_module  # type: ignore
+
+    psutil = psutil_module
 except Exception:  # pragma: no cover - optional dependency
     psutil = None
+structlog: Optional[ModuleType]
 try:
-    import structlog
+    import structlog as structlog_module
+
+    structlog = structlog_module
 except Exception:  # pragma: no cover - optional
     structlog = None
-from config_utils import load_config
 
 
 @dataclass(init=False)
@@ -183,9 +191,11 @@ class Config:
                 raise ValueError(
                     "AUTO_APPROVAL_RULES entries require 'action', 'path', 'approve'"
                 )
-            if not isinstance(rule["action"], str) or not isinstance(
-                rule["path"], str
-            ) or not isinstance(rule["approve"], bool):
+            if (
+                not isinstance(rule["action"], str)
+                or not isinstance(rule["path"], str)
+                or not isinstance(rule["approve"], bool)
+            ):
                 raise ValueError("Invalid AUTO_APPROVAL_RULES entry")
 
     @property

--- a/devai/core.py
+++ b/devai/core.py
@@ -149,7 +149,7 @@ class CodeMemoryAI:
         last_time = getattr(self.analyzer, "last_analysis_time", datetime.now())
         idx_len = len(getattr(self.memory, "indexed_ids", []))
         state = f"{last_time.isoformat()}-{idx_len}"
-        return hashlib.md5(f"{query}-{state}".encode()).hexdigest()
+        return hashlib.sha256(f"{query}-{state}".encode()).hexdigest()
 
     async def _prefetch_related(self, query: str) -> None:
         """Preload memories and suggestions in background."""
@@ -591,7 +591,7 @@ class CodeMemoryAI:
             )
             evaluation = await evaluate_change_with_ia(diff)
             status = "shadow_failed" if not tests_ok else "shadow_declined"
-            patch_hash = hashlib.sha1(diff.encode("utf-8")).hexdigest()
+            patch_hash = hashlib.sha256(diff.encode("utf-8")).hexdigest()
             log_simulation(
                 sim_id,
                 file_path,

--- a/devai/decision_log.py
+++ b/devai/decision_log.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from datetime import datetime
 from pathlib import Path
-from typing import Tuple, List, Dict
+from typing import Any, Dict, List, Tuple
 
 import yaml  # type: ignore
 
@@ -26,7 +26,7 @@ def log_decision(
 ) -> Tuple[str, str]:
     """Register a decision entry in ``decision_log.yaml`` and ``decision_log.md``."""
     path = Path("decision_log.yaml")
-    data = []
+    data: List[dict[str, Any]] = []
     if path.exists():
         try:
             data = yaml.safe_load(path.read_text()) or []
@@ -36,7 +36,7 @@ def log_decision(
             data = []
     entry_id = f"{len(data) + 1:03d}"
     h = hashlib.sha256(resultado.encode()).hexdigest()[:8]
-    entry = {
+    entry: dict[str, Any] = {
         "id": entry_id,
         "tipo": tipo,
         "modulo": modulo,
@@ -72,7 +72,7 @@ def is_remembered(action: str, path: str) -> bool:
     if not log_path.exists():
         return False
     try:
-        data = yaml.safe_load(log_path.read_text()) or []
+        data: List[dict[str, Any]] = yaml.safe_load(log_path.read_text()) or []
     except Exception:
         return False
     for entry in reversed(data):
@@ -94,7 +94,7 @@ def is_remembered(action: str, path: str) -> bool:
     return False
 
 
-def suggest_rules(threshold: int) -> List[Dict[str, str]]:
+def suggest_rules(threshold: int) -> List[Dict[str, Any]]:
     """Return candidate auto approval rules based on the decision log."""
     if threshold <= 0:
         return []
@@ -102,7 +102,7 @@ def suggest_rules(threshold: int) -> List[Dict[str, str]]:
     if not log_path.exists():
         return []
     try:
-        data = yaml.safe_load(log_path.read_text()) or []
+        data: List[dict[str, Any]] = yaml.safe_load(log_path.read_text()) or []
     except Exception:
         return []
     counts: Dict[tuple[str, str], int] = {}


### PR DESCRIPTION
## Summary
- add module docstring and function docstrings for `plugin_manager`
- wrap long strings and break long lines
- adjust code formatting with isort and flake8 compliance
- refine type hints for optional imports and decision logging
- log errors when unregistering plugins
- use SHA-256 hashing instead of weak algorithms
- use `shutil.which` when invoking git/pytest

## Testing
- `pre-commit run --files devai/__main__.py devai/analyzer.py devai/core.py devai/learning_engine.py devai/shadow_mode.py devai/test_runner.py` *(fails: import errors)*
- `flake8 devai` *(fails: many style errors)*
- `pylint devai` *(crashed due to BrokenPipeError)*
- `mypy devai` *(failed: output truncated)*
- `bandit -r devai` *(reported subprocess issues)*
- `pytest -q` *(failures and blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_684e55297900832093944511b9c3f71c