### PR TITLE
Add plugin usage docs and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,17 @@ pre-commit run --all-files
 ## Plugins
 
 Coloque scripts Python em `plugins/` para adicionar novas tarefas ao sistema.
-Cada plugin deve implementar uma função `register(task_manager)`.
+Cada plugin deve implementar uma função `register(task_manager)` e, opcionalmente,
+`unregister(task_manager)`.
 Veja `plugins/todo_counter.py` como exemplo.
+
+### Habilitando ou desabilitando plugins
+
+1. Inicie a CLI com `python -m devai --cli`.
+2. Execute `/plugins` para listar o status de cada plugin.
+3. Use `/plugin <nome> on` para ativar o plugin desejado.
+4. Use `/plugin <nome> off` para desativá‑lo.
+5. O estado fica salvo em `plugins.sqlite` e é carregado automaticamente.
 
 Você também pode rodar os testes e a análise estática pelo gerenciador de tarefas:
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -27,3 +27,6 @@ def register(tm):
     }
     setattr(tm, '_perform_todo_counter_task', _perform_todo_counter_task.__get__(tm))
 ```
+
+Para iniciar um plugin do zero, copie `plugin_template.py` e ajuste o nome,
+descrição e lógica da tarefa conforme necessidade.

--- a/plugins/plugin_template.py
+++ b/plugins/plugin_template.py
@@ -1,0 +1,38 @@
+"""Template simples para novos plugins.
+
+Copie este arquivo para `plugins/<nome>.py` e ajuste as funções.
+"""
+
+# pylint: disable=no-value-for-parameter
+
+PLUGIN_INFO = {
+    "name": "Example Plugin",
+    "version": "0.1",
+    "description": "Descreva o que o plugin faz",
+}
+
+
+def register(task_manager):
+    """Registrar tarefas ou métodos no TaskManager."""
+
+    async def _perform_example(self, task, *args):
+        # implemente o comportamento da tarefa
+        return ["ok"]
+
+    task_manager.tasks["example"] = {
+        "name": "Exemplo",
+        "type": "example",
+        "description": "Explicação breve",
+    }
+    setattr(
+        task_manager,
+        "_perform_example",
+        _perform_example.__get__(task_manager),
+    )
+
+
+def unregister(task_manager):
+    """Remover tarefas e limpar atributos."""
+    task_manager.tasks.pop("example", None)
+    if hasattr(task_manager, "_perform_example"):
+        delattr(task_manager, "_perform_example")


### PR DESCRIPTION
## Summary
- detail steps to enable or disable plugins in the README
- document plugin architecture and show example usage
- add a template for new plugins and reference it in plugin docs

## Testing
- `pre-commit run --files README.md docs/ARCHITECTURE.md plugins/README.md plugins/plugin_template.py`
- `./scripts/dev_checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f4f4727788320b784c6a480061ef0