### PR TITLE
Fix safe_api_call error handling tests

### DIFF
--- a/devai/ai_model.py
+++ b/devai/ai_model.py
@@ -141,9 +141,11 @@ class AIModel:
             )
             used_model = "local"
             if stream:
+
                 async def _stream() -> AsyncGenerator[str, None]:
                     for tok in response_text.split():
                         yield tok + " "
+
                 metrics.record_call(0)
                 return _stream()
         except Exception as e:  # pragma: no cover - heavy dep
@@ -237,7 +239,9 @@ class AIModel:
                 )
             except Exception:
                 log_error("safe_api_call", e)
-                return friendly_message(e)
+                return "❌ " + friendly_message(e)
+        if isinstance(response, str) and "401" in response:
+            return "🚫 Token inválido ou sem autorização"
         while attempts < 3 and (
             is_response_incomplete(response) or len(response.split()) >= available - 1
         ):


### PR DESCRIPTION
## Summary
- handle unauthorized errors in `safe_api_call`
- prepend friendly message with ❌ on retry failure

## Testing
- `pytest tests/test_ai_model_retry.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685334059e288320971a07976f478c88