### PR TITLE
Fix patch recursion in command_router

### DIFF
--- a/devai/command_router.py
+++ b/devai/command_router.py
@@ -5,7 +5,7 @@ import re
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
-from .patch_utils import split_diff_by_file, apply_patch
+from .patch_utils import split_diff_by_file, apply_patch as _apply_patch
 
 from rich.panel import Panel
 
@@ -20,6 +20,18 @@ except Exception:  # pragma: no cover - fallback for tests
     from .update_manager import UpdateManager
 from . import approval
 from .approval import requires_approval, request_approval
+
+
+def apply_patch(diff_text: str) -> None:
+    """Wrapper around patch_utils.apply_patch avoiding recursion."""
+    if getattr(apply_patch, "_in_call", False):
+        _apply_patch(diff_text)
+        return
+    try:
+        apply_patch._in_call = True
+        _apply_patch(diff_text)
+    finally:
+        apply_patch._in_call = False
 
 
 def _new_updater():


### PR DESCRIPTION
## Summary
- avoid recursive loops when `command_router.apply_patch` is monkeypatched

## Testing
- `pre-commit run --files devai/command_router.py` *(fails: Module import errors)*
- `flake8 devai` *(fails: many style issues)*
- `pylint devai` *(fails: import errors)*
- `mypy devai` *(fails: type errors)*
- `bandit -r devai`
- `pytest` *(fails: multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_685467dc5c8c8320a465a5856e421da4