### PR TITLE
Implement long code generation chain

### DIFF
--- a/devai/__init__.py
+++ b/devai/__init__.py
@@ -1,6 +1,7 @@
 from .conversation_handler import ConversationHandler
 from .dialog_summarizer import DialogSummarizer
 from .patch_utils import apply_patch_to_file, split_diff_by_file, apply_patch
+from .generation_chain import generate_long_code
 
 __all__ = [
     "ConversationHandler",
@@ -8,4 +9,5 @@ __all__ = [
     "DialogSummarizer",
     "apply_patch_to_file",
     "split_diff_by_file",
+    "generate_long_code",
 ]

--- a/devai/context_manager.py
+++ b/devai/context_manager.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class CodeContext:
+    """Container for incremental code generation context."""
+
+    history: List[str] = field(default_factory=list)
+
+    def append(self, text: str) -> None:
+        """Add generated chunk to the internal history."""
+        self.history.append(text)
+
+    def text(self) -> str:
+        """Return full context text."""
+        return "\n".join(self.history)

--- a/devai/generation_chain.py
+++ b/devai/generation_chain.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from .ai_model import AIModel
+from .config import config
+from .context_manager import CodeContext
+from .post_processor import is_valid_python, fix_code
+
+
+def _sliding_windows(lines: list[str], size: int, overlap: float) -> Iterable[str]:
+    step = max(1, int(size * (1 - overlap)))
+    for start in range(0, len(lines), step):
+        end = start + size
+        yield "\n".join(lines[start:end])
+        if end >= len(lines):
+            break
+
+
+async def generate_long_code(
+    prompt: str,
+    model: AIModel,
+    context: CodeContext | None = None,
+    *,
+    window_size: int = 50,
+    overlap_ratio: float = 0.1,
+) -> str:
+    """Generate long code using a sliding window approach."""
+    lines = prompt.splitlines()
+    context = context or CodeContext()
+    generated_parts: list[str] = []
+    for chunk in _sliding_windows(lines, window_size, overlap_ratio):
+        ctx_text = context.text()
+        full_prompt = f"{ctx_text}\n{chunk}" if ctx_text else chunk
+        part = await model.safe_api_call(full_prompt, config.MAX_CONTEXT_LENGTH)
+        generated_parts.append(part)
+        context.append(part)
+    result = "\n".join(generated_parts)
+    if not is_valid_python(result):
+        result = fix_code(result)
+    return result

--- a/devai/post_processor.py
+++ b/devai/post_processor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+import black
+
+
+def is_valid_python(code: str) -> bool:
+    """Check if ``code`` compiles without SyntaxError."""
+    try:
+        ast.parse(code)
+        return True
+    except SyntaxError:
+        return False
+
+
+def fix_code(code: str) -> str:
+    """Attempt to format ``code`` using black, returning original on failure."""
+    try:
+        return black.format_str(code, mode=black.FileMode())
+    except Exception:
+        return code


### PR DESCRIPTION
## Summary
- add simple `CodeContext` container
- implement `generate_long_code` with sliding-window logic
- expose `generate_long_code` from package init
- include basic code post-processing utilities

## Testing
- `pre-commit run --files devai/generation_chain.py devai/__init__.py devai/context_manager.py devai/post_processor.py` *(fails: import errors)*
- `pytest` *(fails: 2 tests failed and interrupted)*
- `flake8 devai`
- `pylint devai` *(interrupted)*
- `mypy devai` *(interrupted)*
- `bandit -r devai`

------
https://chatgpt.com/codex/tasks/task_e_6858bb4a24788320bc90ee209ea6b0f3