### PR TITLE
Implement CodeContext with AST parsing

### DIFF
--- a/devai/__init__.py
+++ b/devai/__init__.py
@@ -2,6 +2,7 @@ from .conversation_handler import ConversationHandler
 from .dialog_summarizer import DialogSummarizer
 from .patch_utils import apply_patch_to_file, split_diff_by_file, apply_patch
 from .generation_chain import generate_long_code
+from .context_manager import CodeContext
 
 __all__ = [
     "ConversationHandler",
@@ -10,4 +11,5 @@ __all__ = [
     "apply_patch_to_file",
     "split_diff_by_file",
     "generate_long_code",
+    "CodeContext",
 ]

--- a/devai/context_manager.py
+++ b/devai/context_manager.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Set, Dict
 
 
 @dataclass
@@ -9,11 +10,53 @@ class CodeContext:
     """Container for incremental code generation context."""
 
     history: List[str] = field(default_factory=list)
+    imports: Set[str] = field(default_factory=set)
+    functions: Set[str] = field(default_factory=set)
+    variables: Set[str] = field(default_factory=set)
+
+    def update(self, text: str) -> None:
+        """Append ``text`` and analyze its structure using ``ast``."""
+
+        self.history.append(text)
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            return
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    self.imports.add(alias.asname or alias.name.split(".")[0])
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self.functions.add(node.name)
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    self._collect_names(target)
+            elif isinstance(node, ast.AnnAssign):
+                self._collect_names(node.target)
+
+    def _collect_names(self, node: ast.AST) -> None:
+        if isinstance(node, ast.Name):
+            self.variables.add(node.id)
+        elif isinstance(node, (ast.Tuple, ast.List)):
+            for elt in node.elts:
+                self._collect_names(elt)
 
     def append(self, text: str) -> None:
-        """Add generated chunk to the internal history."""
-        self.history.append(text)
+        """Backward compatible wrapper for :meth:`update`."""
+
+        self.update(text)
 
     def text(self) -> str:
         """Return full context text."""
+
         return "\n".join(self.history)
+
+    def get_summary(self) -> Dict[str, List[str]]:
+        """Return a summary of captured imports, functions and variables."""
+
+        return {
+            "imports": sorted(self.imports),
+            "functions": sorted(self.functions),
+            "variables": sorted(self.variables),
+        }


### PR DESCRIPTION
## Summary
- expand `context_manager.CodeContext` to track imports, functions and variables
- expose `CodeContext` from `devai.__init__`

## Testing
- `flake8 devai`
- `pylint devai/context_manager.py`
- `mypy devai` *(fails: type errors in other modules)*
- `bandit -r devai`
- `pytest -q` *(fails: tests and KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6858c1b8e934832081476df1bb5f7aa3