### PR TITLE
Add post processor utilities

### DIFF
--- a/devai/__init__.py
+++ b/devai/__init__.py
@@ -3,6 +3,7 @@ from .dialog_summarizer import DialogSummarizer
 from .patch_utils import apply_patch_to_file, split_diff_by_file, apply_patch
 from .generation_chain import generate_long_code
 from .context_manager import CodeContext
+from .post_processor import is_valid_python, fix_code
 
 __all__ = [
     "ConversationHandler",
@@ -12,4 +13,6 @@ __all__ = [
     "split_diff_by_file",
     "generate_long_code",
     "CodeContext",
+    "is_valid_python",
+    "fix_code",
 ]

--- a/devai/post_processor.py
+++ b/devai/post_processor.py
@@ -1,13 +1,28 @@
+"""Utility functions for validating and repairing generated Python code."""
+
 from __future__ import annotations
 
 import ast
-from typing import Any
 
-import black
+import autopep8
+
+_BLOCK_KEYWORDS = (
+    "def ",
+    "class ",
+    "if ",
+    "elif ",
+    "else",
+    "for ",
+    "while ",
+    "try",
+    "except",
+    "finally",
+)
 
 
 def is_valid_python(code: str) -> bool:
-    """Check if ``code`` compiles without SyntaxError."""
+    """Return ``True`` if *code* can be parsed as valid Python."""
+
     try:
         ast.parse(code)
         return True
@@ -15,9 +30,27 @@ def is_valid_python(code: str) -> bool:
         return False
 
 
+def _add_missing_colons(code: str) -> str:
+    """Add colons to block statements that are missing them."""
+
+    lines = code.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if any(
+            stripped.startswith(k) for k in _BLOCK_KEYWORDS
+        ) and not stripped.endswith(":"):
+            lines[i] = line.rstrip() + ":"
+    return "\n".join(lines)
+
+
 def fix_code(code: str) -> str:
-    """Attempt to format ``code`` using black, returning original on failure."""
+    """Return ``code`` formatted with autopep8 and basic syntax fixes."""
+
+    formatted = code
+    if not is_valid_python(formatted):
+        formatted = _add_missing_colons(formatted)
     try:
-        return black.format_str(code, mode=black.FileMode())
+        formatted = autopep8.fix_code(formatted)
     except Exception:
-        return code
+        pass
+    return formatted if is_valid_python(formatted) else code

--- a/tests/test_post_processor.py
+++ b/tests/test_post_processor.py
@@ -1,0 +1,19 @@
+import textwrap
+from devai.post_processor import is_valid_python, fix_code
+
+
+def test_is_valid_python():
+    assert is_valid_python("print(1)")
+    assert not is_valid_python("print(")
+
+
+def test_fix_code_adds_missing_colon():
+    bad_code = textwrap.dedent(
+        """
+    def foo()
+        return 1
+    """
+    )
+    fixed = fix_code(bad_code)
+    assert is_valid_python(fixed)
+    assert "def foo():" in fixed


### PR DESCRIPTION
## Summary
- format and repair code with autopep8 in `post_processor`
- export new helpers in package init
- test syntax fixing of generated code

## Testing
- `black devai/post_processor.py devai/__init__.py tests/test_post_processor.py`
- `mypy devai/post_processor.py` *(fails: missing stubs)*
- `pytest tests/test_post_processor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c650506c83209a19d441018ec771