### PR TITLE
Add generate endpoint with session continuations

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -11,6 +11,10 @@ A aplicação expõe uma API FastAPI para interação com a IA e operações de 
   ```bash
   curl "http://localhost:8000/analyze_stream?query=exemplo"
   ```
+- `POST /generate` – gera código longo em partes. Envie `cont=true` para receber o próximo trecho.
+  ```bash
+  curl -X POST http://localhost:8000/generate -d "prompt=def func(): pass"
+  ```
 - `POST /reset_conversation` – reinicia o histórico de uma sessão.
   ```bash
   curl -X POST http://localhost:8000/reset_conversation -d "session_id=default"

--- a/devai/cli.py
+++ b/devai/cli.py
@@ -93,6 +93,7 @@ async def cli_main(
     print("/feedback <arquivo> <tag> <motivo> - Registrar feedback negativo")
     print("/refatorar <arquivo> - Refatora o arquivo informado")
     print("/rever <arquivo> - Executa revisão de código")
+    print("/gerar <prompt> - Gera código longo em partes")
     print("/resetar - Limpa o histórico de conversa")
     print("/tests_local - Alterna execução isolada dos testes")
     print("/sair - Encerra")

--- a/devai/command_router.py
+++ b/devai/command_router.py
@@ -554,6 +554,20 @@ async def handle_rever(ai, ui, args, *, plain, feedback_db):
             print(json.dumps(item, indent=2))
 
 
+async def handle_gerar(ai, ui, args, *, plain, feedback_db):
+    cont = args.strip().lower() == "continuar"
+    if cont:
+        res = await ai.generate_code(None, continue_session=True)
+    else:
+        if not args:
+            print("Uso: /gerar <prompt>")
+            return
+        res = await ai.generate_code(args)
+    print(res["chunk"])
+    if not res["done"]:
+        print("Digite /gerar continuar para mais.")
+
+
 async def handle_resetar(ai, ui, args, *, plain, feedback_db):
     ai.conv_handler.reset("default")
     print("Conversa resetada.")
@@ -806,6 +820,7 @@ COMMANDS = {
     "feedback": handle_feedback,
     "refatorar": handle_refatorar,
     "rever": handle_rever,
+    "gerar": handle_gerar,
     "aprovar_proxima": handle_aprovar_proxima,
     "aprovar_durante": handle_aprovar_durante,
     "modo": handle_modo,

--- a/tests/test_generate_endpoint.py
+++ b/tests/test_generate_endpoint.py
@@ -1,0 +1,52 @@
+import asyncio
+import types
+from datetime import datetime
+
+from devai.core import CodeMemoryAI
+from devai.conversation_handler import ConversationHandler
+from devai.config import config
+from devai import generation_chain
+
+
+def fake_long_code(prompt, model, context=None, window_size=50, overlap_ratio=0.1):
+    lines = [f"line{i}" for i in range(120)]
+    return "\n".join(lines)
+
+
+class DummyModel:
+    async def safe_api_call(self, prompt, max_tokens, context="", memory=None, temperature=0.7):
+        return "ok"
+
+
+def test_generate_chunks(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(generation_chain, "generate_long_code", fake_long_code)
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(search=lambda *a, **k: [])
+    ai.analyzer = types.SimpleNamespace(graph_summary=lambda: "", code_chunks={}, last_analysis_time=datetime.now())
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.ai_model = DummyModel()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.reason_stack = []
+    ai.double_check = False
+
+    record = {}
+    app = types.SimpleNamespace()
+    def fake_post(path):
+        def decorator(fn):
+            record[path] = fn
+            return fn
+        return decorator
+    app.get = app.post = fake_post
+    app.mount = lambda *a, **k: None
+    ai.app = app
+
+    CodeMemoryAI._setup_api_routes(ai)
+
+    res1 = asyncio.run(record['/generate'](prompt='anything', session_id='s', cont=False))
+    assert not res1['done']
+    assert res1['chunk'].startswith('line0')
+
+    res2 = asyncio.run(record['/generate'](prompt='', session_id='s', cont=True))
+    assert res2['done']
+    assert 'line50' in res2['chunk']


### PR DESCRIPTION
## Summary
- implement `/generate` route backed by `generate_long_code`
- keep code generation sessions for continuation
- expose generation in CLI via `/gerar`
- document new API endpoint
- test generation endpoint

## Testing
- `flake8 devai`
- `pylint devai` *(fails: code rated at 8.40/10)*
- `mypy devai` *(fails: missing types-PyYAML stubs)*
- `bandit -r devai`
- `pytest -q` *(fails: Interrupted with collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68591b3db4d4832094da69ed224c30dd