### PR TITLE
Add CodeContext multi-chunk tests

### DIFF
--- a/devai/context_manager.py
+++ b/devai/context_manager.py
@@ -19,7 +19,7 @@ class CodeContext:
 
         self.history.append(text)
         try:
-            tree = ast.parse(text)
+            tree = ast.parse(self.text())
         except SyntaxError:
             return
 

--- a/tests/test_code_context.py
+++ b/tests/test_code_context.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import CodeContext without triggering heavy dependencies
+spec = importlib.util.spec_from_file_location(
+    "devai.context_manager",
+    Path(__file__).resolve().parents[1] / "devai" / "context_manager.py",
+)
+context_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = context_module
+spec.loader.exec_module(context_module)
+CodeContext = context_module.CodeContext
+
+
+def test_basic_update_accumulates_imports_and_functions():
+    ctx = CodeContext()
+    ctx.update("import os\n")
+    ctx.update("def foo():\n    pass\n")
+    assert ctx.imports == {"os"}
+    assert ctx.functions == {"foo"}
+
+
+def test_function_signature_split_across_updates():
+    ctx = CodeContext()
+    ctx.update("def bar(x,\n")
+    assert "bar" not in ctx.functions
+    ctx.update("        y):\n    return x + y\n")
+    assert "bar" in ctx.functions


### PR DESCRIPTION
## Summary
- update `CodeContext.update` to parse the full history
- add tests for `CodeContext` covering multi-chunk updates

## Testing
- `pytest tests/test_code_context.py -q`
- `flake8 devai/context_manager.py tests/test_code_context.py`
- `bandit -r devai`
- `pylint -E devai/context_manager.py`
- `mypy devai` *(fails: missing stubs for PyYAML, autopep8)*


------
https://chatgpt.com/codex/tasks/task_e_685928f0f5148320a709382bfc820ae3