### PR TITLE
Split requirements and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,10 @@ Este arquivo fornece instruções ao agente Codex sobre como executar, testar e 
 
 ## Comandos de Configuração e Execução
 
-- **Instalar dependências**: `pip install -r requirements.txt`
-  (Instala todas as bibliotecas Python necessárias listadas em requirements.txt)
+- **Instalar dependências**:
+  1. `pip install -r requirements-core.txt` (núcleo do projeto)
+  2. `pip install -r requirements-ml.txt` (bibliotecas de IA)
+  3. `pip install -r requirements-ui.txt` (interface opcional)
 - **Instalar ferramentas de desenvolvimento**: `pip install -r requirements-dev.txt`
   (Instala flake8, pylint, mypy, bandit, pre-commit e demais utilitários.)
 

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -4,7 +4,8 @@ Este arquivo permite descrever comandos e convenções específicas do projeto. 
 
 ## Comandos principais
 
-- **Instalar dependências:** `pip install -r requirements.txt`
+- **Instalar dependências:**
+  `pip install -r requirements-core.txt && pip install -r requirements-ml.txt && pip install -r requirements-ui.txt`
 - **Executar testes:** `pytest`
 - **Verificar estilo:** `flake8 devai`
 - **Análise estática:** `pylint devai && mypy devai`

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ API_SECRET: "sua-chave"
    variável diretamente no ambiente. O DevAI carrega esse arquivo
    automaticamente se o pacote `python-dotenv` estiver instalado.
 
-3. Instale as dependências do projeto para habilitar a comunicação real com o OpenRouter e as ferramentas de desenvolvimento (linters, testes etc.):
+3. Instale as dependências do projeto em etapas. Isso evita baixar todos os pacotes pesados de uma só vez:
 
 ```bash
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
-# dependências extras para UI e RLHF (opcional)
-pip install transformers trl rich prompt_toolkit textual
+pip install -r requirements-core.txt      # núcleo do DevAI
+pip install -r requirements-ml.txt        # bibliotecas de IA avançada
+pip install -r requirements-ui.txt        # interface web e TUI
+pip install -r requirements-dev.txt       # ferramentas de desenvolvimento
 ```
 
 Caso pretenda utilizar a interface web incluída em `static/`, instale também as

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -11,10 +11,10 @@ Este guia resume os passos iniciais para rodar o DevAI-R1.
    Os utilitários de desenvolvimento (`flake8`, `pylint`, `mypy`, `bandit` e
    `pre-commit`) estão listados em `requirements-dev.txt`.
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements-core.txt
+   pip install -r requirements-ml.txt
+   pip install -r requirements-ui.txt
    pip install -r requirements-dev.txt
-   # dependências extras para UI e RLHF (opcional)
-   pip install transformers trl rich prompt_toolkit textual
    ```
 3. **Copie e ajuste a configuração**
    ```bash

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,0 +1,15 @@
+fastapi>=0.110
+uvicorn>=0.29
+aiofiles>=23.1
+aiohttp>=3.9
+structlog
+networkx>=3.2
+numpy
+scikit-learn>=1.3
+psutil
+PyYAML
+pydantic
+PyJWT
+python-dotenv
+unidiff
+autopep8

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,0 +1,4 @@
+sentence-transformers
+faiss-cpu
+transformers
+trl==0.7.11

--- a/requirements-ui.txt
+++ b/requirements-ui.txt
@@ -1,0 +1,3 @@
+rich
+prompt_toolkit
+textual<0.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,3 @@
-fastapi>=0.110
-uvicorn>=0.29
-aiofiles>=23.1
-aiohttp>=3.9
-structlog
-networkx>=3.2
-numpy
-scikit-learn>=1.3
-sentence-transformers
-faiss-cpu
-transformers
-psutil
-PyYAML
-pydantic
-PyJWT
-python-dotenv
-# UI dependencies
-rich
-prompt_toolkit
-textual<0.31
-unidiff
-trl==0.7.11
-autopep8
+-r requirements-core.txt
+-r requirements-ml.txt
+-r requirements-ui.txt


### PR DESCRIPTION
## Summary
- break requirements.txt into separate smaller files
- update docs to install each requirements file individually
- document new install steps in AGENTS and guides

## Testing
- `flake8 devai` *(fails: E501 line too long)*
- `pylint devai` *(failed: command timed out)*
- `mypy devai` *(failed: command timed out)*
- `bandit -r devai`
- `pytest` *(fails: 1 error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e6cf38e208320bd3323742e9bc2cf