### PR TITLE
Fix logging reasons and pydantic compatibility

### DIFF
--- a/devai/api_schemas.py
+++ b/devai/api_schemas.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, validator
 
 from .config import config
 
@@ -19,12 +19,12 @@ class FileEditRequest(BaseModel):
     line: int = Field(..., ge=1)
     content: str
 
-    @field_validator("file")
+    @validator("file")
     @classmethod
     def _file_validator(cls, v: str) -> str:
         return _validate_path(v)
 
-    @field_validator("content")
+    @validator("content")
     @classmethod
     def _content_not_empty(cls, v: str) -> str:
         if not v.strip():
@@ -36,7 +36,7 @@ class FileCreateRequest(BaseModel):
     file: str
     content: str = ""
 
-    @field_validator("file")
+    @validator("file")
     @classmethod
     def _file_validator(cls, v: str) -> str:
         return _validate_path(v)
@@ -45,7 +45,7 @@ class FileCreateRequest(BaseModel):
 class FileDeleteRequest(BaseModel):
     file: str
 
-    @field_validator("file")
+    @validator("file")
     @classmethod
     def _file_validator(cls, v: str) -> str:
         return _validate_path(v)
@@ -54,7 +54,7 @@ class FileDeleteRequest(BaseModel):
 class DirRequest(BaseModel):
     path: str
 
-    @field_validator("path")
+    @validator("path")
     @classmethod
     def _path_validator(cls, v: str) -> str:
         return _validate_path(v)
@@ -64,12 +64,12 @@ class ApplyRefactorRequest(BaseModel):
     file_path: str
     diff: str
 
-    @field_validator("file_path")
+    @validator("file_path")
     @classmethod
     def _file_validator(cls, v: str) -> str:
         return _validate_path(v)
 
-    @field_validator("diff")
+    @validator("diff")
     @classmethod
     def _diff_not_empty(cls, v: str) -> str:
         if not v.strip():

--- a/devai/command_router.py
+++ b/devai/command_router.py
@@ -22,16 +22,20 @@ from . import approval
 from .approval import requires_approval, request_approval
 
 
+_apply_patch_lock = False
+
+
 def apply_patch(diff_text: str) -> None:
     """Wrapper around patch_utils.apply_patch avoiding recursion."""
-    if getattr(apply_patch, "_in_call", False):
+    global _apply_patch_lock
+    if _apply_patch_lock:
         _apply_patch(diff_text)
         return
     try:
-        apply_patch._in_call = True
+        _apply_patch_lock = True
         _apply_patch(diff_text)
     finally:
-        apply_patch._in_call = False
+        _apply_patch_lock = False
 
 
 def _new_updater():

--- a/devai/prompt_engine.py
+++ b/devai/prompt_engine.py
@@ -241,9 +241,7 @@ def build_dynamic_prompt(
         "diff",
     ]
     if intent in {"edit", "create"} or any(k in q for k in modify_keywords):
-        prompt += (
-            "Retorne apenas um patch de diff unificado e envolva-o em um bloco markdown com `diff` para facilitar a detecção.\n"
-        )
+        prompt += "Retorne apenas um patch de diff unificado e envolva-o em um bloco markdown com `diff` para facilitar a detecção.\n"
 
     keywords = ["por que", "por quê", "analise", "detalhe", "explique", "entenda"]
     explain_intents = {"debug", "architecture", "review"}
@@ -251,7 +249,11 @@ def build_dynamic_prompt(
         prompt += "Explique antes de responder." + extra
     else:
         prompt += extra
-    logger.info("Prompt dinâmico", included_blocks=included, reasons=reasons, mode=mode)
+    logger.info(
+        f"Prompt dinâmico reasons={reasons}",
+        included_blocks=included,
+        mode=mode,
+    )
     return prompt
 
 

--- a/unresolved_errors.jsonl
+++ b/unresolved_errors.jsonl
@@ -1,2 +1,3 @@
 {"timestamp": "2025-06-23T13:20:10Z", "tipo": "TestFailure", "mensagem": "tests/test_cli.py::test_cli_patch_apply_accept", "funcao": "pytest"}
 {"timestamp": "2025-06-26T17:45:04Z", "tipo": "StyleError", "mensagem": "flake8 devai produced errors", "funcao": "scripts/dev_checks.sh"}
+{"timestamp": "2025-06-27T10:46:30Z", "tipo": "TestFailure", "mensagem": "tests/test_cli.py::test_cli_patch_apply_accept fails due to recursive monkeypatch", "funcao": "command_router.apply_patch"}


### PR DESCRIPTION
## Summary
- support pydantic v1 validators
- log reasons directly in prompt_engine
- guard against recursive patch application
- record unresolved failing test

## Testing
- `pytest tests/test_dynamic_prompt.py::test_dynamic_prompt_logs_reasons -q`

------
https://chatgpt.com/codex/tasks/task_e_685e732551f8832095873597cc5bc2e4