### PR TITLE
Add external data suggestion

### DIFF
--- a/devai/command_router.py
+++ b/devai/command_router.py
@@ -790,6 +790,14 @@ async def handle_default(
         ui.console.print(response)
     ui.add_history(response)
     ui.show_history()
+    if ai.external_data_needed:
+        confirm = True
+        if ui:
+            confirm = await ui.confirm(
+                "Não possuo informações suficientes… Deseja buscar com o Scraper_Wiki?"
+            )
+        if confirm:
+            await ai.start_scrape(args)
 
 
 COMMANDS = {


### PR DESCRIPTION
## Summary
- add heuristic for uncertain answers in CodeMemoryAI
- suggest using Scraper_Wiki when memory is insufficient or model confidence is low
- handle external data suggestion in CLI flow

## Testing
- `pre-commit run --files devai/core.py devai/command_router.py` *(fails: B110, B324, import errors)*
- `flake8 devai`
- `pylint devai` *(rated 8.41/10)*
- `mypy devai` *(fails: missing stubs and undefined names)*
- `bandit -r devai`
- `pytest` *(fails: ImportPathMismatchError in Scraper_Wiki tests)*

------
https://chatgpt.com/codex/tasks/task_e_685e7b7d0e648320a2c69685237696f2