### PR TITLE
Add scraper interface and aprender command

### DIFF
--- a/devai/__init__.py
+++ b/devai/__init__.py
@@ -4,6 +4,7 @@ from .patch_utils import apply_patch_to_file, split_diff_by_file, apply_patch
 from .generation_chain import generate_long_code
 from .context_manager import CodeContext
 from .post_processor import is_valid_python, fix_code
+from .scraper_interface import run_scrape
 
 __all__ = [
     "ConversationHandler",
@@ -15,4 +16,5 @@ __all__ = [
     "CodeContext",
     "is_valid_python",
     "fix_code",
+    "run_scrape",
 ]

--- a/devai/scraper_interface.py
+++ b/devai/scraper_interface.py
@@ -1,0 +1,63 @@
+"""Wrapper utilities for the Scraper Wiki project."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional, Any
+
+
+def _run_sync(func: Any, *args: Any, **kwargs: Any) -> Any:
+    """Execute a blocking function in a thread."""
+    return asyncio.to_thread(func, *args, **kwargs)
+
+
+async def run_scrape(topic: str, lang: Optional[str] = None, depth: int = 1, **opts: Any) -> Any:
+    """Run Scraper Wiki to gather data about a topic.
+
+    Parameters
+    ----------
+    topic:
+        Topic, category or URL to scrape.
+    lang:
+        Optional language code.
+    depth:
+        Crawling depth when using dynamic scraping.
+    opts:
+        Extra options like ``plugin`` or ``threads``.
+    """
+
+    plugin = opts.get("plugin", "wikipedia")
+
+    if plugin == "github":
+        from Scraper_Wiki.cli import auto_scrape
+
+        threads = int(opts.get("threads", 2))
+        return await _run_sync(auto_scrape, [topic], depth=depth, threads=threads)
+
+    import scraper_wiki
+
+    fmt = opts.get("format", "all")
+    rate_delay = opts.get("rate_limit_delay")
+    revisions = bool(opts.get("revisions", False))
+    rev_limit = int(opts.get("rev_limit", 5))
+    translate_to = opts.get("translate_to")
+    incremental = bool(opts.get("incremental", False))
+
+    langs = [lang] if lang else None
+    categories = [topic]
+
+    return await _run_sync(
+        scraper_wiki.main,
+        langs,
+        categories,
+        fmt,
+        rate_delay,
+        start_pages=None,
+        depth=depth,
+        revisions=revisions,
+        rev_limit=rev_limit,
+        translate_to=translate_to,
+        incremental=incremental,
+    )
+
+__all__ = ["run_scrape"]

--- a/tests/test_scraper_interface.py
+++ b/tests/test_scraper_interface.py
@@ -1,0 +1,43 @@
+import sys
+import types
+import asyncio
+
+import devai.scraper_interface as si
+
+
+def test_run_scrape_main(monkeypatch):
+    called = {}
+    fake_module = types.ModuleType("scraper_wiki")
+    def fake_main(langs, cats, fmt, rate_delay=None, *, start_pages=None, depth=1, **kwargs):
+        called['langs'] = langs
+        called['cats'] = cats
+        called['depth'] = depth
+    fake_module.main = fake_main
+    sys.modules['scraper_wiki'] = fake_module
+
+    async def fake_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(si, 'asyncio', types.SimpleNamespace(to_thread=fake_to_thread))
+
+    asyncio.run(si.run_scrape('AI', 'pt', 2))
+    assert called == {'langs': ['pt'], 'cats': ['AI'], 'depth': 2}
+
+
+def test_run_scrape_auto(monkeypatch):
+    called = {}
+    fake_cli = types.ModuleType('Scraper_Wiki.cli')
+    def fake_auto(urls, depth=1, threads=2):
+        called['urls'] = urls
+        called['depth'] = depth
+    fake_cli.auto_scrape = fake_auto
+    sys.modules['Scraper_Wiki.cli'] = fake_cli
+
+    async def fake_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(si, 'asyncio', types.SimpleNamespace(to_thread=fake_to_thread))
+
+    asyncio.run(si.run_scrape('http://example.com', None, 3, plugin='github'))
+    assert called == {'urls': ['http://example.com'], 'depth': 3}
+


### PR DESCRIPTION
## Summary
- add `scraper_interface.run_scrape` wrapper calling Scraper Wiki
- expose `run_scrape` from package
- allow `/aprender <topic>` command with flag parsing
- test scraper interface behaviour

## Testing
- `./scripts/dev_checks.sh` *(failed: flake8 E501 and others)*
- `pytest` *(failed during collection: ImportPathMismatchError)*
- `pytest tests/test_scraper_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_685e80465bd883209f5c3e07278f1b33