### PR TITLE
Implement memory TTL feature

### DIFF
--- a/devai/command_router.py
+++ b/devai/command_router.py
@@ -66,6 +66,12 @@ async def handle_ajuda(ai, ui, args, *, plain, feedback_db):
 
 
 async def handle_memoria(ai, ui, args, *, plain, feedback_db):
+    m_tmp = re.search(r"temporaria\s+(\d+)", args)
+    if m_tmp:
+        ai.temp_memory_hours = int(m_tmp.group(1))
+        print(f"Tempo de retenção temporária definido para {m_tmp.group(1)} horas")
+        return
+
     detailed = "--detalhado" in args
     if detailed:
         args = args.replace("--detalhado", "").strip()

--- a/devai/core.py
+++ b/devai/core.py
@@ -118,6 +118,7 @@ class CodeMemoryAI:
         # Rastreamento de loops e watchers em execução
         self.watchers: Dict[str, asyncio.Task] = {}
         self.last_average_complexity = 0.0
+        self.temp_memory_hours: int | None = None
         self.reason_stack = []
         self.response_cache: "OrderedDict[str, Dict]" = OrderedDict()
         self.response_cache_size = 32


### PR DESCRIPTION
## Summary
- add `expires_at` column and TTL parameter for MemoryManager.save
- prune expired entries in memory pruning process
- support `/memoria temporaria <horas>` command to set temporary memory duration
- expose temp_memory_hours attribute in CodeMemoryAI
- test TTL expiration handling

## Testing
- `flake8 devai/memory.py devai/command_router.py devai/core.py`
- `mypy devai` *(fails: Name "np" is not defined, etc)*
- `bandit -r devai`
- `pytest` *(fails: ImportPathMismatchError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e84fffe648320aa48fe46f379a17a