### PR TITLE
Add scrape metrics and progress reporting

### DIFF
--- a/Scraper_Wiki/scraper_wiki/__init__.py
+++ b/Scraper_Wiki/scraper_wiki/__init__.py
@@ -1998,7 +1998,9 @@ class DatasetBuilder:
         try:
             os.makedirs(Config.LOG_DIR, exist_ok=True)
             progress_file = os.path.join(Config.LOG_DIR, "progress.json")
+            scraper_file = os.path.join(Config.LOG_DIR, "scraper_progress.json")
             temp_file = progress_file + ".tmp"
+            temp_file_new = scraper_file + ".tmp"
 
             clusters = sorted(
                 {item.get("cluster") for item in self.dataset if "cluster" in item}
@@ -2026,6 +2028,10 @@ class DatasetBuilder:
             with open(temp_file, "w", encoding="utf-8") as f:
                 json.dump(progress, f, ensure_ascii=False, indent=2)
             os.replace(temp_file, progress_file)
+
+            with open(temp_file_new, "w", encoding="utf-8") as f:
+                json.dump(progress, f, ensure_ascii=False, indent=2)
+            os.replace(temp_file_new, scraper_file)
 
             data_path = os.path.join(Config.LOG_DIR, "checkpoint_data.json")
             pages_path = os.path.join(Config.LOG_DIR, "checkpoint_pages.json")

--- a/Scraper_Wiki/tests/test_scraper_wiki.py
+++ b/Scraper_Wiki/tests/test_scraper_wiki.py
@@ -2157,6 +2157,7 @@ def test_dataset_builder_initializes_from_checkpoints(tmp_path, monkeypatch):
     assert builder.dataset == data
     assert builder.pending_pages == pages
     assert (Path(tmp_path) / "progress.json").exists()
+    assert (Path(tmp_path) / "scraper_progress.json").exists()
 
 
 def test_save_dataset_strips_credentials(tmp_path, monkeypatch):

--- a/devai/config.py
+++ b/devai/config.py
@@ -275,6 +275,20 @@ class Metrics:
                 )
             except Exception:
                 pass
+        try:
+            from importlib import import_module
+
+            sw_metrics = import_module("Scraper_Wiki.metrics")
+            data.update(
+                {
+                    "scrape_success": sw_metrics.scrape_success._value.get(),
+                    "scrape_errors": sw_metrics.scrape_error._value.get(),
+                    "scrape_blocks": sw_metrics.scrape_block._value.get(),
+                    "pages_scraped_total": sw_metrics.pages_scraped_total._value.get(),
+                }
+            )
+        except Exception:
+            pass
         return data
 
 

--- a/devai/core.py
+++ b/devai/core.py
@@ -242,6 +242,16 @@ class CodeMemoryAI:
             pass
         return 0.0
 
+    def _scraper_progress(self) -> dict:
+        """Return scraping progress from status file."""
+        try:
+            path = Path(config.LOG_DIR) / "scraper_progress.json"
+            if path.exists():
+                return json.loads(path.read_text())
+        except Exception:
+            pass
+        return {}
+
     def start_deep_scan(self) -> bool:
         """Queue deep_scan_app as background task if not running."""
         if not hasattr(self, "background_tasks"):
@@ -514,6 +524,10 @@ class CodeMemoryAI:
         @self.app.get("/metrics")
         async def get_metrics():
             return metrics.summary()
+
+        @self.app.get("/stats")
+        async def get_stats():
+            return self._scraper_progress()
 
         @self.app.get("/logs/recent")
         async def recent_logs(limit: int = 20):

--- a/devai/scraper_interface.py
+++ b/devai/scraper_interface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Optional, Any
 
 
@@ -52,6 +53,10 @@ async def run_scrape(
         return await _run_sync(auto_scrape, [topic], depth=depth, threads=threads)
 
     import scraper_wiki
+
+    scraper_wiki.metrics.start_metrics_server(
+        int(os.environ.get("METRICS_PORT", "8001"))
+    )
     from .data_ingestion import ingest_directory
     from .memory import MemoryManager
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,7 @@
 from devai.config import metrics
+import sys
+import types
+
 
 def test_summary_has_cpu_memory_keys():
     data = metrics.summary()
@@ -7,3 +10,21 @@ def test_summary_has_cpu_memory_keys():
     assert "cpu_percent" in data or "memory_percent" in data or True
     assert "model_usage" in data
     assert "incomplete_percent" in data
+
+
+def test_summary_includes_scraper_metrics(monkeypatch):
+    class Dummy:
+        def __init__(self, val):
+            self._value = types.SimpleNamespace(get=lambda: val)
+
+    fake = types.SimpleNamespace(
+        scrape_success=Dummy(1),
+        scrape_error=Dummy(2),
+        scrape_block=Dummy(3),
+        pages_scraped_total=Dummy(4),
+    )
+    monkeypatch.setitem(sys.modules, "Scraper_Wiki.metrics", fake)
+    data = metrics.summary()
+    assert data["scrape_success"] == 1
+    assert data["scrape_errors"] == 2
+    assert data["pages_scraped_total"] == 4

--- a/tests/test_scraper_interface.py
+++ b/tests/test_scraper_interface.py
@@ -7,37 +7,63 @@ import devai.scraper_interface as si
 
 def test_run_scrape_main(monkeypatch):
     called = {}
+    fake_metrics = types.SimpleNamespace(start_metrics_server=lambda *a, **k: None)
     fake_module = types.ModuleType("scraper_wiki")
-    def fake_main(langs, cats, fmt, rate_delay=None, *, start_pages=None, depth=1, **kwargs):
-        called['langs'] = langs
-        called['cats'] = cats
-        called['depth'] = depth
+
+    def fake_main(
+        langs, cats, fmt, rate_delay=None, *, start_pages=None, depth=1, **kwargs
+    ):
+        called["langs"] = langs
+        called["cats"] = cats
+        called["depth"] = depth
+
     fake_module.main = fake_main
-    sys.modules['scraper_wiki'] = fake_module
+    fake_module.metrics = fake_metrics
+    sys.modules["scraper_wiki"] = fake_module
 
     async def fake_to_thread(func, *a, **k):
         return func(*a, **k)
 
-    monkeypatch.setattr(si, 'asyncio', types.SimpleNamespace(to_thread=fake_to_thread))
+    monkeypatch.setattr(si, "asyncio", types.SimpleNamespace(to_thread=fake_to_thread))
 
-    asyncio.run(si.run_scrape('AI', 'pt', 2))
-    assert called == {'langs': ['pt'], 'cats': ['AI'], 'depth': 2}
+    asyncio.run(si.run_scrape("AI", "pt", 2))
+    assert called == {"langs": ["pt"], "cats": ["AI"], "depth": 2}
 
 
 def test_run_scrape_auto(monkeypatch):
     called = {}
-    fake_cli = types.ModuleType('Scraper_Wiki.cli')
+    fake_cli = types.ModuleType("Scraper_Wiki.cli")
+
     def fake_auto(urls, depth=1, threads=2):
-        called['urls'] = urls
-        called['depth'] = depth
+        called["urls"] = urls
+        called["depth"] = depth
+
     fake_cli.auto_scrape = fake_auto
-    sys.modules['Scraper_Wiki.cli'] = fake_cli
+    sys.modules["Scraper_Wiki.cli"] = fake_cli
 
     async def fake_to_thread(func, *a, **k):
         return func(*a, **k)
 
-    monkeypatch.setattr(si, 'asyncio', types.SimpleNamespace(to_thread=fake_to_thread))
+    monkeypatch.setattr(si, "asyncio", types.SimpleNamespace(to_thread=fake_to_thread))
 
-    asyncio.run(si.run_scrape('http://example.com', None, 3, plugin='github'))
-    assert called == {'urls': ['http://example.com'], 'depth': 3}
+    asyncio.run(si.run_scrape("http://example.com", None, 3, plugin="github"))
+    assert called == {"urls": ["http://example.com"], "depth": 3}
 
+
+def test_run_scrape_starts_metrics(monkeypatch):
+    called = {"port": None}
+    fake_metrics = types.SimpleNamespace(
+        start_metrics_server=lambda port=8001: called.update({"port": port})
+    )
+    fake_module = types.ModuleType("scraper_wiki")
+    fake_module.main = lambda *a, **k: None
+    fake_module.metrics = fake_metrics
+    sys.modules["scraper_wiki"] = fake_module
+
+    async def fake_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(si, "asyncio", types.SimpleNamespace(to_thread=fake_to_thread))
+
+    asyncio.run(si.run_scrape("AI"))
+    assert called["port"] == 8001

--- a/tests/test_stats_endpoint.py
+++ b/tests/test_stats_endpoint.py
@@ -1,0 +1,62 @@
+import types
+import json
+import asyncio
+from datetime import datetime
+
+from devai.core import CodeMemoryAI
+from devai.conversation_handler import ConversationHandler
+from devai.config import config
+
+
+def _setup_ai(log_dir):
+    ai = object.__new__(CodeMemoryAI)
+    ai.memory = types.SimpleNamespace(
+        search=lambda *a, **k: [],
+        recent_entries=lambda *a, **k: [],
+        indexed_ids=[],
+    )
+    ai.analyzer = types.SimpleNamespace(
+        code_chunks={},
+        learned_rules=[],
+        last_analysis_time=datetime.now(),
+        scan_progress=0.0,
+        get_code_graph=lambda: {},
+        read_lines=lambda *a, **k: [],
+        list_dir=lambda *a, **k: [],
+        edit_line=lambda *a, **k: True,
+        create_file=lambda *a, **k: True,
+        delete_file=lambda *a, **k: True,
+        create_directory=lambda *a, **k: True,
+        delete_directory=lambda *a, **k: True,
+    )
+    ai.history = types.SimpleNamespace(history=lambda *a, **k: [])
+    ai.tasks = types.SimpleNamespace(last_actions=lambda: [])
+    ai.log_monitor = types.SimpleNamespace()
+    ai.conv_handler = ConversationHandler(memory=ai.memory)
+    ai.reason_stack = []
+    ai.double_check = False
+    ai.app = types.SimpleNamespace()
+    routes = {}
+
+    def fake_get(path):
+        def decorator(fn):
+            routes[path] = fn
+            return fn
+
+        return decorator
+
+    ai.app.get = ai.app.post = fake_get
+    ai.app.mount = lambda *a, **k: None
+    config.LOG_DIR = str(log_dir)
+    CodeMemoryAI._setup_api_routes(ai)
+    return routes
+
+
+def test_stats_endpoint(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "scraper_progress.json").write_text(json.dumps({"p": 1}))
+
+    routes = _setup_ai(log_dir)
+    result = asyncio.run(routes["/stats"]())
+    assert result["p"] == 1


### PR DESCRIPTION
## Summary
- start Prometheus metrics server on scrape run
- track scraper progress into `scraper_progress.json`
- expose scraper progress via `/stats` endpoint
- include scraper metrics in summary data
- test metrics startup and stats endpoint

## Testing
- `flake8 devai`
- `bandit -r devai`
- `pytest tests/test_metrics.py tests/test_scraper_interface.py::test_run_scrape_main tests/test_scraper_interface.py::test_run_scrape_auto tests/test_scraper_interface.py::test_run_scrape_starts_metrics tests/test_stats_endpoint.py -q --import-mode=importlib`
- `pytest Scraper_Wiki/tests/test_scraper_wiki.py -k dataset_builder_initializes_from_checkpoints -q --import-mode=importlib` *(fails: ModuleNotFoundError: No module named 'graphviz')*

------
https://chatgpt.com/codex/tasks/task_e_685fb31ca3e08320b36fab2989bbbcb7