### PR TITLE
Add Scraper_Wiki integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,35 @@ python -m devai --cli
 /tarefa static_analysis
 ```
 
+## Scraper_Wiki Integration
+
+O comando `/aprender` integra o [Scraper\_Wiki](Scraper_Wiki/README.md) para
+buscar dados externos e incorporá-los à memória vetorial. Execute a CLI e
+chame:
+
+```bash
+/aprender "engenharia de software" --lang=pt --depth=2
+```
+
+Os arquivos gerados são processados e salvos em `memory.sqlite`,
+`faiss.index` e `faiss_ids.json`. Defina caminhos customizados no
+`config.yaml` com `INDEX_FILE` e `INDEX_IDS_FILE`. Para ingerir registros de
+forma temporária utilize `/integrar temporario`.
+
+Para agendar execuções automáticas configure a variável de ambiente
+`SCRAPER_SCHEDULE` com uma expressão cron. Plugins específicos podem exigir
+`API_TOKEN`, `GITHUB_TOKEN`, `GITLAB_TOKEN` ou `SONARQUBE_TOKEN`. Guarde esses
+segredos em um arquivo `.env` fora do controle de versão.
+
+A documentação HTML do Scraper\_Wiki pode ser gerada em
+`Scraper_Wiki/` com:
+
+```bash
+cd Scraper_Wiki
+pdoc -o docs -d google integrations core plugins utils api
+```
+
+
 ## Treinamento RLHF
 
 Depois de registrar feedback positivo via API ou CLI, é possível refinar o modelo base utilizando a biblioteca [`trl`](https://github.com/huggingface/trl) e o `SFTTrainer`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,3 +127,28 @@ def register(task_manager):
 Esse registro adiciona a tarefa `todo_counter` ao gerenciador e vincula um método
 assíncrono. Caso o plugin seja desativado, o `PluginManager` remove a tarefa e
 chama `unregister()` se definido.
+
+## Scraper_Wiki Integration
+
+O wrapper `devai.scraper_interface.run_scrape` permite executar o projeto
+Scraper\_Wiki a partir do DevAI. A CLI expõe essa funcionalidade no comando
+`/aprender`, que dispara o scraper e integra os arquivos gerados ao
+`MemoryManager`.
+
+Exemplo de uso:
+
+```bash
+/aprender "engenharia de software" --lang=pt --depth=2
+```
+
+Memórias temporárias podem ser adicionadas com `/integrar temporario`. O
+agendamento de coletas usa a variável `SCRAPER_SCHEDULE`. Tokens como
+`API_TOKEN` ou `GITHUB_TOKEN` devem ser definidos em um `.env` e nunca
+versionados.
+
+Para gerar a documentação HTML do Scraper\_Wiki execute em seu diretório:
+
+```bash
+pdoc -o docs -d google integrations core plugins utils api
+```
+


### PR DESCRIPTION
## Summary
- document how DevAI integrates Scraper_Wiki in README and ARCHITECTURE docs
- include `/aprender` command example, memory persistence details and variables
- add instructions for generating Scraper_Wiki docs via pdoc

## Testing
- `pre-commit run --files README.md docs/ARCHITECTURE.md`
- `pytest` *(fails: ImportError: cannot import name 'AutoModelForCausalLM')*

------
https://chatgpt.com/codex/tasks/task_e_685fbb2cdd088320a49b5bbace75fd4f